### PR TITLE
ReadOnly TextField/Area + some migrations to sass + fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,13 @@ module.exports = {
     "react/require-default-props": 0,
     "import/no-extraneous-dependencies": 2,
     "react/jsx-filename-extension": 0,
+    "jsx-a11y/label-has-for": [ 2, {
+      "components": [ "Label" ],
+      "required": {
+          "every": [ "id" ]
+      },
+      "allowChildren": false,
+  }],
     // TODO: activate this one when it is ready
     // waiting for this: https://github.com/airbnb/javascript/pull/1482
     "jsx-a11y/href-no-hash": 0,

--- a/src/alto-ui/Button/Button.js
+++ b/src/alto-ui/Button/Button.js
@@ -16,12 +16,16 @@ const buttonProps = bemProps('button', [
 ]);
 
 const Button = props => (
-  <button {...buttonProps(props)} />
+  props.href
+  ? <a {...buttonProps(props)} href={props.href}>{props.children}</a>
+  : <button {...buttonProps(props)} />
 );
 
 Button.displayName = 'Button';
 
 Button.propTypes = {
+  children: PropTypes.any,
+  href: PropTypes.string,
   outline: PropTypes.bool,
   flat: PropTypes.bool,
   error: PropTypes.bool,

--- a/src/alto-ui/Button/Button.js
+++ b/src/alto-ui/Button/Button.js
@@ -1,20 +1,36 @@
-import bem from '../helpers/bem';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bemProps } from '../helpers/bem';
 import './Button.scss';
 
-const modifiers = [
+const buttonProps = bemProps('button', [
   'outline',
   'flat',
-  'error',
+  'danger',
   'success',
   'white',
   'large',
   'small',
   'active',
   'block',
-];
+]);
 
-const Button = bem('button', 'button', modifiers);
+const Button = props => (
+  <button {...buttonProps(props)} />
+);
 
 Button.displayName = 'Button';
+
+Button.propTypes = {
+  outline: PropTypes.bool,
+  flat: PropTypes.bool,
+  error: PropTypes.bool,
+  success: PropTypes.bool,
+  white: PropTypes.bool,
+  large: PropTypes.bool,
+  small: PropTypes.bool,
+  active: PropTypes.bool,
+  block: PropTypes.bool,
+}
 
 export default Button;

--- a/src/alto-ui/Button/Button.scss
+++ b/src/alto-ui/Button/Button.scss
@@ -139,6 +139,11 @@ $color-white-button-focus: $blue-30;  // Focus ring for white buttons
   padding: .9375rem 1.8125rem;
 }
 
+.button--block {
+  display: block;
+  width: 100%;
+}
+
 
 // Outline
 

--- a/src/alto-ui/Button/story.js
+++ b/src/alto-ui/Button/story.js
@@ -159,4 +159,13 @@ storiesOf('Button', module)
         </Button>
       </SimpleWrapper>
     );
-  });
+  })
+  .addWithJSX('link', () => {
+    const modifiers = getModifiers();
+
+    return (
+      <SimpleWrapper white={modifiers.white}>
+        <Button href={text('href', '#some-url')} {...modifiers}>{text('children', 'I am a <a /> tag!')}</Button>
+      </SimpleWrapper>
+    );
+  })

--- a/src/alto-ui/Button/story.js
+++ b/src/alto-ui/Button/story.js
@@ -33,7 +33,7 @@ SimpleWrapper.displayName = 'Story';
 const modifierNames = [
   'outline',
   'flat',
-  'error',
+  'danger',
   'success',
   'white',
   'large',
@@ -82,7 +82,7 @@ storiesOf('Button', module)
     );
   })
   .addWithJSX('colors', () => {
-    const modifiers = getModifiers('error', 'success', 'white');
+    const modifiers = getModifiers('danger', 'success', 'white');
 
     return (
       <SimpleWrapper>
@@ -90,14 +90,14 @@ storiesOf('Button', module)
         <Button {...modifiers} success>
           success
         </Button>
-        <Button {...modifiers} error>
-          error
+        <Button {...modifiers} danger>
+          danger
         </Button>
       </SimpleWrapper>
     );
   })
   .addWithJSX('white', () => {
-    const modifiers = getModifiers('error', 'success', 'white', 'flat', 'outline');
+    const modifiers = getModifiers('danger', 'success', 'white', 'flat', 'outline');
 
     return (
       <SimpleWrapper white>

--- a/src/alto-ui/Form/CheckBox/story.js
+++ b/src/alto-ui/Form/CheckBox/story.js
@@ -2,12 +2,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import withReadme from 'storybook-readme/with-readme';
+import centered from '@storybook/addon-centered';
 
 import CheckBox from './CheckBox';
 import README from './README.md';
 
 storiesOf('Form/CheckBox', module)
 .addDecorator(withReadme(README))
+.addDecorator(centered)
 .addWithJSX('overview', () => (
   <div>
     <CheckBox id="unchecked" label="Unchecked" />

--- a/src/alto-ui/Form/FormElement/FormElement.js
+++ b/src/alto-ui/Form/FormElement/FormElement.js
@@ -1,56 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
 
-import { getColor, fontSize } from '../../helpers/theme';
-
-const modifier = (...ms) => val => props =>
-  ms.reduce((acc, m) => acc && props[m], true) ? val : '';
-
-
-const FormElementWrapper = styled.div`
-  margin-bottom: 20px;
-`;
-
-const FormElementHelpText = styled.div`
-  ${fontSize('small')};
-  text-align: left;
-  font-weight: 600;
-  padding: 10px 0;
-  color: ${getColor('coolGrey.50')};
-
-  ${modifier('success')(css`
-    color: ${getColor('success')};
-  `)} ${modifier('error')(css`
-      color: ${getColor('error')};
-    `)} ${modifier('disabled')(css`
-      color: ${getColor('coolGrey.20')};
-    `)};
-`;
-
-const FormElementLabel = styled.label`
-  ${fontSize('small')};
-  font-weight: 700;
-  color: ${getColor('coolGrey.50')};
-  text-align: left;
-  padding-bottom: 10px;
-  display: block;
-`;
+import { bemClass } from '../../helpers/bem';
+import Label from '../Label';
+import './FormElement.scss';
 
 const FormElement = props => {
-  const { error, disabled, success, id, children } = props;
+  const { error, disabled, success, id, children, readOnly } = props;
   return (
-    <FormElementWrapper>
-      <FormElementLabel htmlFor={id} id={`${id}__label`} {...{ error, disabled, success }}>
+    <div className="form-element">
+      <Label htmlFor={id} id={`${id}__label`} readOnly={readOnly}>
         {props.label}
-      </FormElementLabel>
+      </Label>
       {children}
       {props.helpText && (
-        <FormElementHelpText id={`${id}__help-text`} {...{ error, disabled, success }}>
+        <div className={bemClass('form-element__help-text', { error, disabled, success })} id={`${id}__help-text`}>
           {props.helpText}
-        </FormElementHelpText>
+        </div>
       )}
-    </FormElementWrapper>
+    </div>
   );
 };
 
@@ -61,6 +29,7 @@ FormElement.propTypes = {
   error: PropTypes.bool,
   disabled: PropTypes.bool,
   success: PropTypes.bool,
+  readOnly: PropTypes.bool,
   children: PropTypes.element.isRequired,
 };
 

--- a/src/alto-ui/Form/FormElement/FormElement.scss
+++ b/src/alto-ui/Form/FormElement/FormElement.scss
@@ -1,0 +1,26 @@
+@import "../../scss/inc";
+
+.form-element {
+  margin-bottom: 20px;
+}
+
+.form-element__help-text {
+  font-size: $font-size-small;
+  text-align: left;
+  font-weight: $font-weight-semibold;
+  padding: 10px 0;
+  color: $coolgrey-50;
+}
+
+
+.form-element__help-text--success {
+  color: $green;
+}
+
+.form-element__help-text--error {
+  color: $red;
+}
+
+.form-element__help-text--disabled {
+  color: $coolgrey-20;
+}

--- a/src/alto-ui/Form/Label/Label.js
+++ b/src/alto-ui/Form/Label/Label.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { bemProps } from '../../helpers/bem';
+import './Label.scss';
+
+const labelProps = bemProps('label', ['readOnly'])
+
+const Label = props => (
+  <label {...labelProps(props)} htmlFor={props.htmlFor} />
+);
+
+
+Label.displayName = 'Label';
+
+Label.defaultProps = {
+};
+
+Label.propTypes = {
+  htmlFor: PropTypes.string,
+};
+
+export default Label;

--- a/src/alto-ui/Form/Label/Label.scss
+++ b/src/alto-ui/Form/Label/Label.scss
@@ -1,0 +1,15 @@
+@import "../../scss/inc";
+
+.label {
+  font-size: $font-size-small;
+  font-weight: 700;
+  color: $coolgrey-50;
+  text-align: left;
+  padding-bottom: 10px;
+  display: block;
+  border-bottom: 1px solid transparent;
+}
+
+.label--read-only {
+  border-bottom-color:$coolgrey-20;
+}

--- a/src/alto-ui/Form/Label/README.md
+++ b/src/alto-ui/Form/Label/README.md
@@ -1,0 +1,7 @@
+# Label
+
+## Usage
+
+```js
+<Label></Label>
+```

--- a/src/alto-ui/Form/Label/index.js
+++ b/src/alto-ui/Form/Label/index.js
@@ -1,0 +1,1 @@
+export { default } from './Label';

--- a/src/alto-ui/Form/Label/story.js
+++ b/src/alto-ui/Form/Label/story.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import centered from '@storybook/addon-centered';
+
+import Label from './Label';
+import README from './README.md';
+
+storiesOf('Form/Label', module)
+  .addDecorator(withReadme(README))
+  .addDecorator(centered)
+  .addWithJSX('playground', () => (
+    <Label htmlFor="foo">label</Label>
+    ));

--- a/src/alto-ui/Form/TextArea/TextArea.js
+++ b/src/alto-ui/Form/TextArea/TextArea.js
@@ -1,22 +1,10 @@
 import React from 'react';
-
-import { TextFieldTag } from '../TextField';
-import FormElement from '../FormElement';
-
-
-export const TextAreaTag = TextFieldTag.withComponent('textarea').extend`
-  height: 8em;
-`;
-
-TextAreaTag.displayName = 'TextAreaTag';
+import TextField from '../TextField';
 
 const TextArea = props => (
-  <FormElement {...props}>
-    <TextAreaTag {...props} />
-  </FormElement>
+  <TextField {...props} area />
 );
 
 TextArea.displayName = 'TextArea';
-
 
 export default TextArea;

--- a/src/alto-ui/Form/TextField/TextField.js
+++ b/src/alto-ui/Form/TextField/TextField.js
@@ -1,95 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
 
-import { getColor, getTheme, fontSize } from '../../helpers/theme';
+import { bemProps } from '../../helpers/bem';
 import FormElement from '../FormElement';
 
-const modifier = (...ms) => val => props =>
-  ms.reduce((acc, m) => acc && props[m], true) ? val : '';
+import './Textfield.scss';
 
-export const resetInput = css`
-  font: inherit;
-  background: transparent;
-  border: 0;
-  outline: 0;
-`;
-
-export const TextFieldTag = styled.input`
-  ${resetInput};
-  ${fontSize('medium')};
-  background: white;
-  color: ${getColor('text')};
-  border-radius: ${getTheme('borderRadius')};
-  border: 1px solid ${getColor('coolGrey.20')};
-  font-weight: 400;
-  line-height: 2.375;
-  padding: 0 10px;
-  display: block;
-  width: 100%;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
-  transition: box-shadow ${getTheme('transition')}, border-color ${getTheme('transition')};
-
-  ::placeholder {
-    color: ${getColor('coolGrey.20')};
-  }
-
-  :hover {
-    box-shadow: 0 2px 1px rgba(0, 0, 0, 0.1);
-  }
-
-  :focus {
-    border-color: ${getColor('primary')};
-    box-shadow: 0 0 0 3px ${getColor('primary.20')};
-  }
-
-  ${modifier('success')(css`
-    border-color: ${getColor('success')};
-    :focus {
-      border-color: ${getColor('success')};
-      box-shadow: 0 0 0 3px ${getColor('success.20')};
-    }
-  `)};
-  ${modifier('error')(css`
-    border-color: ${getColor('error')};
-    :focus {
-      border-color: ${getColor('error')};
-      box-shadow: 0 0 0 3px ${getColor('error.20')};
-    }
-  `)};
-  ${modifier('large')(css`
-    ${fontSize('large')};
-    padding: 0 20px;
-    line-height: 2.67;
-  `)};
-  ${modifier('small')(css`
-    ${fontSize('small')};
-    line-height: 2;
-  `)};
-  :disabled {
-    cursor: not-allowed;
-    color: ${getColor('coolGrey.40')};
-    background: ${getColor('coolGrey.10')};
-    border-color: ${getColor('coolGrey.20')};
-    box-shadow: none;
-  }
-`;
-
-TextFieldTag.displayName = 'Input';
-
-TextFieldTag.defaultProps = {
-  type: 'text',
-};
-
-TextFieldTag.propTypes = {
-  type: PropTypes.string,
-};
+const texfieldProps = bemProps('textfield', ['large', 'small', 'success', 'error', 'area']);
 
 const TextField = props => (
   <FormElement {...props}>
-    <TextFieldTag {...props} />
+    {props.area ? <textarea {...texfieldProps(props, 'helpText', 'type')} type={null} /> : <input {...texfieldProps(props, 'helpText')} />}
   </FormElement>
 );
+
+TextField.defaultProps = {
+  type: 'text',
+};
+
+TextField.propTypes = {
+  type: PropTypes.string,
+  area: PropTypes.bool,
+  large: PropTypes.bool,
+  small: PropTypes.bool,
+  success: PropTypes.bool,
+  error: PropTypes.bool,
+};
 
 TextField.displayName = 'TextField';
 

--- a/src/alto-ui/Form/TextField/TextField.js
+++ b/src/alto-ui/Form/TextField/TextField.js
@@ -4,13 +4,17 @@ import PropTypes from 'prop-types';
 import { bemProps } from '../../helpers/bem';
 import FormElement from '../FormElement';
 
-import './Textfield.scss';
+import './TextField.scss';
 
 const texfieldProps = bemProps('textfield', ['large', 'small', 'success', 'error', 'area']);
 
 const TextField = props => (
   <FormElement {...props}>
-    {props.area ? <textarea {...texfieldProps(props, 'helpText', 'type')} type={null} /> : <input {...texfieldProps(props, 'helpText')} />}
+    {props.area ? (
+      <textarea {...texfieldProps(props, 'helpText', 'type')} type={null} />
+    ) : (
+      <input {...texfieldProps(props, 'helpText')} />
+    )}
   </FormElement>
 );
 

--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -1,0 +1,75 @@
+@import "../../scss/inc";
+
+.textfield {
+  font: inherit;
+  background: transparent;
+  outline: 0;
+
+  font-size: $font-size-medium;
+  background-color: $white;
+  color: $color-text-default;
+  border-radius: $border-radius-default;
+  border: 1px solid $coolgrey-20;
+  font-weight: 400;
+  line-height: 2.375;
+  height: 2.375em;
+  padding: 0 10px;
+  display: block;
+  width: 100%;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  transition: all $transition;
+
+  &::placeholder {
+    color: $coolgrey-20;
+  }
+
+  &:hover {
+    box-shadow: 0 2px 1px rgba(0, 0, 0, 0.1);
+  }
+
+  &:focus {
+    border-color: $blue;
+    box-shadow: 0 0 0 3px $blue-20;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: $coolgrey-40;
+    background: $coolgrey-10;
+    border-color: $coolgrey-20;
+    box-shadow: none;
+  }
+}
+
+.textfield--success {
+  border-color: $green;
+  &:focus {
+    border-color: $green;
+    box-shadow: 0 0 0 3px $green-20;
+  }
+}
+
+.textfield--error {
+  border-color: $red;
+  &:focus {
+    border-color: $red;
+    box-shadow: 0 0 0 3px $red-20;
+  }
+}
+
+.textfield--large {
+  font-size: $font-size-large;
+  padding: 0 20px;
+  line-height: 2.67;
+  height: 2.67em;
+}
+
+.textfield--small {
+  font-size: $font-size-small;
+  line-height: 2;
+  height: 2em;
+}
+
+.textfield--area {
+  height: 8em;
+}

--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -39,6 +39,14 @@
     border-color: $coolgrey-20;
     box-shadow: none;
   }
+
+  &[readonly] {
+    border: 0;
+    padding-left: 0;
+    padding-right: 0;
+    box-shadow: none;
+    background: transparent;
+  }
 }
 
 .textfield--success {

--- a/src/alto-ui/Form/TextField/story.js
+++ b/src/alto-ui/Form/TextField/story.js
@@ -21,7 +21,7 @@ const SimpleWrapper = styled.div`
 
 SimpleWrapper.displayName = 'Story';
 
-const modifierNames = ['success', 'error', 'large', 'small', 'disabled'];
+const modifierNames = ['success', 'error', 'large', 'small', 'area', 'disabled', 'readOnly'];
 
 const getModifiers = (...modifiersExcluded) =>
   modifierNames

--- a/src/alto-ui/Form/story.js
+++ b/src/alto-ui/Form/story.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
+import centered from '@storybook/addon-centered';
+
 // import { text, boolean, select } from '@storybook/addon-knobs';
 
 import Checkbox from './CheckBox';
@@ -15,7 +17,7 @@ const Form = styled.form`width: 600px;`;
 
 Form.displayName = 'form';
 
-storiesOf('Form/Overview', module).addWithJSX('Static example', () => (
+storiesOf('Form/Overview', module).addDecorator(centered).addWithJSX('Static example', () => (
   <Form>
     <TextField id="firtsname" label="First name" placeholder="First name" />
     <TextField id="lastname" label="Last name" placeholder="Last name" />
@@ -54,6 +56,7 @@ storiesOf('Form/Overview', module).addWithJSX('Static example', () => (
 ));
 
 require('./CheckBox/story');
+require('./Label/story');
 require('./RadioButton/story');
 require('./Select/story');
 require('./TextArea/story');

--- a/src/alto-ui/SideNav/SideNav.js
+++ b/src/alto-ui/SideNav/SideNav.js
@@ -21,6 +21,7 @@ class SideNav extends React.PureComponent {
 
     this.handleToggle = this.handleToggle.bind(this);
     this.handleToggleOpen = this.handleToggleOpen.bind(this);
+    this.handleCloseMenu = this.handleCloseMenu.bind(this);
   }
 
   handleToggle() {
@@ -48,6 +49,10 @@ class SideNav extends React.PureComponent {
     this.setState(({ open }) => ({ open: !open }));
   }
 
+  handleCloseMenu() {
+    this.setState(() => ({ open: false }));
+  }
+
   renderNavSubItems(items, open) {
     // if (this.state.collapsed) return [];
 
@@ -55,7 +60,8 @@ class SideNav extends React.PureComponent {
       <li key={item.title}>
         <a
           href={item.url}
-          className={bemClass('SideNav__route-link', {
+          onClick={this.handleCloseMenu}
+          className={bemClass('sidenav__route-link', {
             active: this.props.currentUrl.indexOf(item.url) === 0,
           })}
           tabIndex={open ? 0 : -1}
@@ -72,23 +78,23 @@ class SideNav extends React.PureComponent {
       const open = !this.state.collapsed && !!this.state.sectionsOpenState[item.title];
       const active = !!item.items.find(({ url }) => this.props.currentUrl.indexOf(url) === 0);
       return (
-        <li className="Sidebar__section" key={item.title}>
+        <li className="sidenav__section" key={item.title}>
           <button
-            className={bemClass('SideNav__section-button', { collapsed, active })}
+            className={bemClass('sidenav__section-button', { collapsed, active })}
             onClick={() => this.handleToggleSection(item.title)}
           >
-            <div className="SideNav__section-item">
+            <div className="sidenav__section-item">
               {item.icon && (
-                <div className="SideNav__section-item-icon">
+                <div className="sidenav__section-item-icon">
                   <item.icon outline />
                 </div>
               )}
-              <div className="SideNav__section-item-title">{item.title}</div>
+              <div className="sidenav__section-item-title">{item.title}</div>
               <div
                 className={bemClass(
-                  'SideNav__icon-container',
+                  'sidenav__icon-container',
                   { reverse: open },
-                  'SideNav__section-item-chevron'
+                  'sidenav__section-item-chevron'
                 )}
               >
                 <ChevronDownIcon />
@@ -96,7 +102,7 @@ class SideNav extends React.PureComponent {
             </div>
           </button>
           <ul
-            className="SideNav__sub-list"
+            className="sidenav__sub-list"
             style={{ height: `${open ? item.items.length * 2.5 + 1 : 0}rem` }}
             aria-hidden={!open}
           >

--- a/src/alto-ui/SideNav/SideNav.scss
+++ b/src/alto-ui/SideNav/SideNav.scss
@@ -1,7 +1,7 @@
 @import "../scss/inc";
 
 
-.SideNav {
+.sidenav {
   background-color: $coolgrey-90;
   display: flex;
   flex-direction: column;
@@ -13,13 +13,13 @@
   }
 }
 
-.SideNav--collapsed {
+.sidenav--collapsed {
   @include on-medium-and-wide {
     width: 3.125rem;
   }
 }
 
-.SideNav__header {
+.sidenav__header {
   display: flex;
   align-items: center;
   box-shadow: inset 0 5px 0 $red;
@@ -33,7 +33,7 @@
   }
 }
 
-.SideNav__logo {
+.sidenav__logo {
   font-size: $font-size-x-large;
   font-weight: $font-weight-light;
   display: block;
@@ -62,7 +62,7 @@
   }
 }
 
-.SideNav__button {
+.sidenav__button {
   font: inherit;
   background: transparent;
   border: 0;
@@ -85,13 +85,26 @@
   }
 }
 
-.SideNav__menu-button {
+.sidenav__icon-container {
+  display: flex;
+
+  i {
+    margin: auto;
+    transition: transform $transition;
+  }
+
+  &--reverse i {
+    transform: rotate(-180deg);
+  }
+}
+
+.sidenav__menu-button {
   @include on-medium-and-wide {
     display: none;
   }
 }
 
-.SideNav__sections-list {
+.sidenav__sections-list {
   color: white;
   border-bottom: 1px solid $coolgrey-80;
   flex: 1;
@@ -103,7 +116,7 @@
   }
 }
 
-.SideNav__sections-list-narrow {
+.sidenav__sections-list-narrow {
   list-style: none;
   overflow: auto;
   color: white;
@@ -127,14 +140,14 @@
   }
 }
 
-.SideNav__section {
+.sidenav__section {
   position: relative;
 }
 
 
 
-.SideNav__toggle-button {
-  @extend .SideNav__button;
+.sidenav__toggle-button {
+  @extend .sidenav__button;
   font-size: $font-size-x-large;
 
   @include on-narrow {
@@ -142,9 +155,9 @@
   }
 }
 
-.SideNav__route-link,
-.SideNav__section-button {
-  @extend .SideNav__button;
+.sidenav__route-link,
+.sidenav__section-button {
+  @extend .sidenav__button;
   display: block;
   overflow: hidden;
   box-shadow: inset 0 0 0 $red;
@@ -166,20 +179,7 @@
   }
 }
 
-.SideNav__icon-container {
-  display: flex;
-
-  i {
-    margin: auto;
-    transition: transform $transition;
-  }
-
-  &--reverse i {
-    transform: rotate(-180deg);
-  }
-}
-
-.SideNav__section-item {
+.sidenav__section-item {
   display: flex;
   align-items: center;
 
@@ -188,7 +188,7 @@
   }
 }
 
-.SideNav__section-item-icon {
+.sidenav__section-item-icon {
   font-size: $font-size-x-large;
   width: 3.25rem;
   display: flex;
@@ -199,26 +199,26 @@
   }
 }
 
-.SideNav__section-item-title {
+.sidenav__section-item-title {
   font-size: $font-size-large;
   flex: 1;
   font-weight: 600;
   text-align: left;
 }
 
-.SideNav__section-item-chevron {
+.sidenav__section-item-chevron {
   font-size: $font-size-small;
   width: 3.25rem;
 }
 
-.SideNav__sub-list {
+.sidenav__sub-list {
   list-style: none;
   font-size: $font-size-medium;
   overflow: hidden;
   transition: height $transition;
 }
 
-.SideNav__route-link {
+.sidenav__route-link {
   line-height: 2.5rem;
   height: 2.5rem;
   padding-left: 3.25rem;

--- a/src/alto-ui/Tabs/Tabs.js
+++ b/src/alto-ui/Tabs/Tabs.js
@@ -1,15 +1,14 @@
 import React from 'react';
-import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { bemClass } from '../helpers/bem';
 
 import './Tabs.scss';
 
-const Tabs = ({ items, children, className, currentUrl }) => (
-  <ul className={classnames('tabs', className)}>
+const Tabs = ({ items, children, className, currentUrl, panel }) => (
+  <ul className={bemClass('tabs', { panel }, className)} role="tablist">
     {items.map(item => (
       <li key={item.url} className="tabs__tab">
-        <a className={bemClass('tabs__link', { active: item.url === currentUrl })} href={item.url}>
+        <a className={bemClass('tabs__link', { active: item.url === currentUrl, panel })} href={item.url}>
           {children(item)}
         </a>
       </li>
@@ -25,6 +24,7 @@ Tabs.defaultProps = {
 
 Tabs.propTypes = {
   className: PropTypes.string,
+  panel: PropTypes.bool,
   children: PropTypes.func,
   currentUrl: PropTypes.string,
   items: PropTypes.arrayOf(

--- a/src/alto-ui/Tabs/story.js
+++ b/src/alto-ui/Tabs/story.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { select } from '@storybook/addon-knobs';
+import { select, boolean } from '@storybook/addon-knobs';
 import centered from '@storybook/addon-centered';
 import withReadme from 'storybook-readme/with-readme';
 
@@ -22,6 +22,7 @@ storiesOf('Tabs', module)
   .addDecorator(centered)
   .addWithJSX('overview', () => (
     <Tabs
+      panel={boolean('panel', false)}
       currentUrl={select('currentUrl', ['none'].concat(urls), '#one')}
       items={items}
     />

--- a/src/alto-ui/helpers/bem.js
+++ b/src/alto-ui/helpers/bem.js
@@ -30,11 +30,30 @@ const bem = (ComponentToRender, block, modifiers = [], extraProps = []) => {
 export const bemClass = (block, modifiers, ...others) =>
   classnames(
     block,
-    Object.entries(modifiers).reduce(
-      (acc, [modifier, value]) => Object.assign({}, acc, { [`${block}--${modifier}`]: value }),
-      {}
-    ),
+    Object.keys(modifiers)
+      .filter(modifier => !!modifiers[modifier])
+      .map(modifier => `${block}--${modifier}`),
     ...others
   );
+
+export const bemProps = (block, modifiers, ...others) => (props, extraProps) => {
+  const propsToExclude = modifiers.concat(extraProps);
+  return Object.assign(
+    {},
+    Object.entries(props).reduce(
+      (acc, [prop, value]) =>
+        propsToExclude.includes(prop) ? acc : Object.assign({}, acc, { [prop]: value }),
+      {}
+    ),
+    {
+      className: classnames(
+        block,
+        modifiers.filter(modifier => !!props[modifier]).map(modifier => `${block}--${modifier}`),
+        props.className,
+        ...others
+      ),
+    }
+  );
+};
 
 export default bem;

--- a/src/alto-ui/helpers/bem.js
+++ b/src/alto-ui/helpers/bem.js
@@ -36,6 +36,12 @@ export const bemClass = (block, modifiers, ...others) =>
     ...others
   );
 
+const toDashCase = s => s
+  .trim()
+  .replace(/[A-Z]/g, ' $&')
+  .replace(/( |_|-)+/g,'-')
+  .toLowerCase();
+
 export const bemProps = (block, modifiers, ...others) => (props, extraProps) => {
   const propsToExclude = modifiers.concat(extraProps);
   return Object.assign(
@@ -48,7 +54,7 @@ export const bemProps = (block, modifiers, ...others) => (props, extraProps) => 
     {
       className: classnames(
         block,
-        modifiers.filter(modifier => !!props[modifier]).map(modifier => `${block}--${modifier}`),
+        modifiers.filter(modifier => !!props[modifier]).map(modifier => `${block}--${toDashCase(modifier)}`),
         props.className,
         ...others
       ),


### PR DESCRIPTION
- Lowercase SideNav classNames + close menu onClick item on narrow
- Add panel prop to tabs
- Switch TextField and TextArea to scss
- Update linter, disable label nesting a11y rule
- Use scss for FormElement and create a Label component
- Create readOnly on TextField/Area
- fix uncentered stories
- fix button danger color
- fix button block
- Add Link as Button thanks to href

![input-readonly](https://user-images.githubusercontent.com/5002260/34044156-33f4a982-e1a4-11e7-8627-d7c67d1fb0ae.gif)
