### PR TITLE
ie11 proposed solutions

### DIFF
--- a/src/alto-ui/Icons/Icon.scss
+++ b/src/alto-ui/Icons/Icon.scss
@@ -28,6 +28,8 @@
 
 .icon--button {
   @extend %reset-button;
+  width: auto; //For IE11
+  height: auto; //For IE11
   width: initial;
   height: initial;
 

--- a/src/alto-ui/Icons/Icon.scss
+++ b/src/alto-ui/Icons/Icon.scss
@@ -28,10 +28,8 @@
 
 .icon--button {
   @extend %reset-button;
-  width: auto; //For IE11
-  height: auto; //For IE11
-  width: initial;
-  height: initial;
+  width: auto;
+  height: auto;
 
   cursor: pointer;
   padding: 0.375em;

--- a/src/alto-ui/SideNav/SideNav.scss
+++ b/src/alto-ui/SideNav/SideNav.scss
@@ -126,7 +126,8 @@ $nav-btn-hover-text-dark: $white;
   border-bottom: 1px solid $coolgrey-20;
   flex: 1;
   list-style: none;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   @include on-narrow {
     display: none;


### PR DESCRIPTION
- IE11 does not support css value initial so icon buttons fallback to other rule
- Horizontal scroll bar appears when SideNav collapsed
