### PR TITLE
non-interactive tree items should not have hover style

### DIFF
--- a/src/alto-ui/Tree/components/TreeItem/TreeItem.js
+++ b/src/alto-ui/Tree/components/TreeItem/TreeItem.js
@@ -34,6 +34,7 @@ const renderTreeItem = (id, keyField, item, selected, renderItem, href, onClick,
       {...props}
       className={bemClass('TreeItem__button', {
         active: selected,
+        hoverable: !!(href || onClick),
       })}
     >
       {renderItem(item, selected)}

--- a/src/alto-ui/Tree/components/TreeItem/TreeItem.scss
+++ b/src/alto-ui/Tree/components/TreeItem/TreeItem.scss
@@ -58,15 +58,17 @@
 
   transition: all $transition;
   font-size: $font-size-small;
-  cursor: pointer;
   line-height: 1.6;
   border-radius: 1em;
   padding: 0 $spacing-small;
   white-space: nowrap;
   color: inherit;
 
-  &:hover {
-    background-color: $coolgrey-20;
+  &--hoverable {
+    cursor: pointer;
+    &:hover {
+      background-color: $coolgrey-20;
+    }
   }
 
   &--active {


### PR DESCRIPTION
If Tree Item is not interactive, remove the hovering style and cursor
![ssgif](https://user-images.githubusercontent.com/8788657/41292837-56c6eeee-6e5c-11e8-97fe-780f27553b75.gif)
