### PR TITLE
hoverable attribute can be set per item

### DIFF
--- a/src/alto-ui/Tree/components/TreeItem/TreeItem.js
+++ b/src/alto-ui/Tree/components/TreeItem/TreeItem.js
@@ -64,7 +64,7 @@ const TreeItem = props => {
           {...(typeof onClick === 'function' ? { onClick: handleClick } : {})}
           className={bemClass('TreeItem__button', {
             active: isSelected,
-            hoverable: !!(href || onClick),
+            hoverable: item.hoverable || true,
           })}
         >
           {renderItem(item, isSelected)}


### PR DESCRIPTION
onClick event handler is drilled from Tree component. So, if you have a tree with onClick property, all the nodes are hoverable. In some cases (like parent nodes) this is not intended. So I propose moving hoverable option into treeitem itself