### PR TITLE
Increase contrast for input fields

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
@@ -114,7 +114,7 @@
   cursor: pointer;
   position: relative;
   transition: all $transition;
-  box-shadow: inset 0 0 0 1px $coolgrey-20;
+  box-shadow: inset 0 0 0 1px $color-input-border;
   //border: 1px solid $coolgrey-20;
   .DatagridCell--warning & {
     box-shadow: inset 0 0 0 1px $orange;

--- a/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
@@ -115,6 +115,7 @@
   position: relative;
   transition: all $transition;
   box-shadow: inset 0 0 0 1px $color-input-border;
+  background-color: $white;
   //border: 1px solid $coolgrey-20;
   .DatagridCell--warning & {
     box-shadow: inset 0 0 0 1px $orange;

--- a/src/alto-ui/Form/CheckBox/CheckBox.scss
+++ b/src/alto-ui/Form/CheckBox/CheckBox.scss
@@ -28,7 +28,7 @@
 
   &::before {
     left: 0;
-    border: 1px solid $coolgrey-20;
+    border: 1px solid $color-input-border;
     background-color: white;
     top: 0.5em;
     height: 0.875em;

--- a/src/alto-ui/Form/Radio/Radio.scss
+++ b/src/alto-ui/Form/Radio/Radio.scss
@@ -24,7 +24,7 @@
 
   &::before {
     left: 0;
-    border: 1px solid $coolgrey-20;
+    border: 1px solid $color-input-border;
     background-color: white;
     top: 0.5em;
     height: 1em;

--- a/src/alto-ui/Form/Select/Select.scss
+++ b/src/alto-ui/Form/Select/Select.scss
@@ -7,7 +7,7 @@
   background: $white;
   color: currentColor;
   border-radius: $border-radius-default;
-  border: 1px solid $coolgrey-20;
+  border: 1px solid $color-input-border;
   font-weight: 400;
   height: $height-default;
   display: block;

--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -10,7 +10,7 @@
   background-color: $white;
   color: $color-text-default;
   border-radius: $border-radius-default;
-  border: 1px solid $coolgrey-20;
+  border: 1px solid $color-input-border;
   font-weight: 400;
   line-height: $line-height-input;
   height: $height-default;

--- a/src/alto-ui/scss/variables.scss
+++ b/src/alto-ui/scss/variables.scss
@@ -131,8 +131,8 @@ $coolgrey-90: #192328 !default;
 $coolgrey-80: #333c48 !default;
 $coolgrey-70: #3f4f5e !default;
 $coolgrey-60: #4f6376 !default;
-$coolgrey-50: #637e94 !default;
-$coolgrey-40: #9baec1 !default;
+$coolgrey-50: #758fa3 !default;
+$coolgrey-40: #a3b5c6 !default;
 $coolgrey-30: #bfcedd !default;
 $coolgrey-20: #dae4ed !default;
 $coolgrey-10: #f8f9fb !default;
@@ -355,4 +355,4 @@ $focusable-out-box-shadow: 0 0 0 2px $white, 0 0 0 4px $blue !important;
 // ===================================
 // Forms
 
-$color-input-border: $coolgrey-30 !default;
+$color-input-border: $coolgrey-40 !default;

--- a/src/alto-ui/scss/variables.scss
+++ b/src/alto-ui/scss/variables.scss
@@ -131,8 +131,8 @@ $coolgrey-90: #192328 !default;
 $coolgrey-80: #333c48 !default;
 $coolgrey-70: #3f4f5e !default;
 $coolgrey-60: #4f6376 !default;
-$coolgrey-50: #5f788c !default;
-$coolgrey-40: #8096ac !default;
+$coolgrey-50: #637e94 !default;
+$coolgrey-40: #9baec1 !default;
 $coolgrey-30: #bfcedd !default;
 $coolgrey-20: #dae4ed !default;
 $coolgrey-10: #f8f9fb !default;
@@ -351,3 +351,8 @@ $footer-height: 3rem;
 
 $focusable-box-shadow: inset 0 0 0 2px $blue, inset 0 0 0 4px $white !important;
 $focusable-out-box-shadow: 0 0 0 2px $white, 0 0 0 4px $blue !important;
+
+// ===================================
+// Forms
+
+$color-input-border: $coolgrey-30 !default;


### PR DESCRIPTION
By darkening the borders

### OLD AND BUSTED:
<img width="634" alt="storybook" src="https://user-images.githubusercontent.com/938464/43189719-8ab72dba-8ff7-11e8-9432-125f4d902169.png">

### NEW HOTNESS:
<img width="628" alt="new-darker-borders" src="https://user-images.githubusercontent.com/938464/43189665-60c52eda-8ff7-11e8-8e8f-73edc5335a5d.png">

