### PR TITLE
Feature/buttons/rework

### DIFF
--- a/src/alto-ui/Button/Button.scss
+++ b/src/alto-ui/Button/Button.scss
@@ -80,7 +80,8 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
   $color-hover-text,
   $color-focus,
   $color-hover-bkgd,
-  $color-active-bkgd
+  $color-active-bkgd,
+  $color-active-text
 ) {
   color: $color-default;
 
@@ -106,6 +107,7 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 
   &.button--active {
     background: $color-active-bkgd;
+    color: $color-active-text;
   }
 
   &:disabled,
@@ -124,9 +126,10 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
   font-weight: $font-weight-semibold;
   font-size: $font-size-medium;
   font-family: $font-family-alt;
-  padding: 0.4375rem 0.75rem; // Button height = 32px
+  padding: 0 0.75rem;
+  height: 1.75rem; // Button height = 32px
   line-height: $line-height-button;
-  border: 1px solid transparent;
+  border: none;
   border-radius: $border-radius-default;
   text-decoration: none;
   text-align: center;
@@ -162,8 +165,9 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 }
 
 .button--small {
-  font-size: $font-size-small;
-  padding: 0.25rem 0.5rem; // Button height = 26px
+  font-size: $font-size-medium;
+  padding: 0 0.5rem;
+  height: 1.5rem; // Button height = 26px
   .icon {
     font-size: $font-size-medium; // Keeps icons in small buttons readable
   }
@@ -171,7 +175,8 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 
 .button--large {
   font-size: $font-size-large;
-  padding: 0.625rem 1.25rem; // Button height = 38px
+  padding: 0 1.25rem;
+  height: 2rem; // Button height = 36px
 }
 
 .button--nowrap {
@@ -223,19 +228,32 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 // Flat
 
 .button--flat {
-  @include button--flat($coolgrey-70, $coolgrey-80, $blue-30, $coolgrey-20, $coolgrey-30);
+  @include button--flat(
+    $coolgrey-60,
+    // Default text
+      $blue-60,
+    // Hover Text
+      $blue-30,
+    // Focus outline
+      transparent,
+    // Hover bkgd
+      $blue-20,
+    //Active bkgd
+      $blue-70
+  );
   background: transparent;
   border-color: transparent;
+  font-weight: 600;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
 
 .button--flat.button--success {
-  @include button--flat($green, $green-80, $green-20, $green-20, $green-30);
+  @include button--flat($green, $green-80, $green-20, $green-20, $green-30, $green);
 }
 
 .button--flat.button--danger {
-  @include button--flat($red, $red-80, $red-20, $red-20, $red-30);
+  @include button--flat($red, $red-80, $red-20, $red-20, $red-30, $red);
 }
 
 .button--flat.button--white {
@@ -244,6 +262,7 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
     rgba($white, 0.8),
     $color-white-button-focus,
     rgba($white, 0.2),
-    rgba($white, 0.3)
+    rgba($white, 0.3),
+    $white
   );
 }

--- a/src/alto-ui/Button/Button.scss
+++ b/src/alto-ui/Button/Button.scss
@@ -127,7 +127,7 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
   font-size: $font-size-medium;
   font-family: $font-family-alt;
   padding: 0 0.75rem;
-  height: 1.75rem; // Button height = 32px
+  height: $height-default; // Button height = 32px
   line-height: $line-height-button;
   border: none;
   border-radius: $border-radius-default;

--- a/src/alto-ui/Button/Button.scss
+++ b/src/alto-ui/Button/Button.scss
@@ -230,16 +230,11 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 .button--flat {
   @include button--flat(
     $coolgrey-60,
-    // Default text
-      $blue-60,
-    // Hover Text
-      $blue-30,
-    // Focus outline
-      transparent,
-    // Hover bkgd
-      $blue-20,
-    //Active bkgd
-      $blue-70
+    $blue-60,
+    $blue-30,
+    transparent,
+    $blue-20,
+    $blue-70
   );
   background: transparent;
   border-color: transparent;

--- a/src/alto-ui/Button/Button.scss
+++ b/src/alto-ui/Button/Button.scss
@@ -75,7 +75,13 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 }
 
 // Flat Buttons
-@mixin button--flat($color-default, $color-hover-text, $color-focus, $color-hover-bkgd) {
+@mixin button--flat(
+  $color-default,
+  $color-hover-text,
+  $color-focus,
+  $color-hover-bkgd,
+  $color-active-bkgd
+) {
   color: $color-default;
 
   &,
@@ -98,8 +104,8 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
     background: $color-hover-bkgd;
   }
 
-  &:active {
-    color: $color-default;
+  &.button--active {
+    background: $color-active-bkgd;
   }
 
   &:disabled,
@@ -115,7 +121,7 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  font-weight: $font-weight-regular;
+  font-weight: $font-weight-semibold;
   font-size: $font-size-medium;
   font-family: $font-family-alt;
   padding: 0.4375rem 0.75rem; // Button height = 32px
@@ -217,7 +223,7 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 // Flat
 
 .button--flat {
-  @include button--flat($blue, $blue-80, $blue-20, $blue-20);
+  @include button--flat($coolgrey-70, $coolgrey-80, $blue-30, $coolgrey-20, $coolgrey-30);
   background: transparent;
   border-color: transparent;
   padding-left: 0.5rem;
@@ -225,13 +231,19 @@ $color-white-button-focus: $blue-30; // Focus ring for white buttons
 }
 
 .button--flat.button--success {
-  @include button--flat($green, $green-80, $green-20, $green-20);
+  @include button--flat($green, $green-80, $green-20, $green-20, $green-30);
 }
 
 .button--flat.button--danger {
-  @include button--flat($red, $red-80, $red-20, $red-20);
+  @include button--flat($red, $red-80, $red-20, $red-20, $red-30);
 }
 
 .button--flat.button--white {
-  @include button--flat($white, rgba($white, 0.8), $color-white-button-focus, rgba($white, 0.2));
+  @include button--flat(
+    $white,
+    rgba($white, 0.8),
+    $color-white-button-focus,
+    rgba($white, 0.2),
+    rgba($white, 0.3)
+  );
 }

--- a/src/alto-ui/Form/Switch/Switch.scss
+++ b/src/alto-ui/Form/Switch/Switch.scss
@@ -1,7 +1,12 @@
 @import '../../scss/inc';
 
 .Switch {
-  padding: $spacing-small 0;
+  //padding: $spacing-small 0;
+  height: $height-default;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 
 .Switch__input {
@@ -13,6 +18,11 @@
   outline: 0;
   display: flex;
   align-items: center;
+  font-weight: $font-weight-semibold;
+  font-family: $font-family-alt;
+  user-select: none;
+  color: $coolgrey-60;
+  cursor: pointer;
 
   .Switch__input:disabled + & {
     cursor: not-allowed;
@@ -26,9 +36,9 @@
   height: 1rem;
   position: relative;
   overflow: hidden;
-  background-color: $coolgrey-50;
+  background-color: $coolgrey-60;
   border-radius: 0.5rem;
-  margin-right: 0.5em;
+  margin-right: 0.25em;
 
   .Switch__input:focus + .Switch__label & {
     box-shadow: 0 0 0 3px $blue-20;
@@ -64,7 +74,7 @@
     height: 1rem;
     border-radius: $border-radius-circle;
     background-color: $white;
-    box-shadow: inset 0 0 0 2px $coolgrey-50;
+    box-shadow: inset 0 0 0 2px $coolgrey-60;
     left: 0;
 
     .Switch__input:checked + .Switch__label & {

--- a/src/alto-ui/scss/variables.scss
+++ b/src/alto-ui/scss/variables.scss
@@ -302,9 +302,9 @@ $line-height-button-large: 2.875rem !default;
 // ===================================
 // Height
 
-$height-small: 1.75rem;
-$height-default: 2rem;
-$height-large: 2.25rem;
+$height-small: 1.5rem;
+$height-default: 1.75rem;
+$height-large: 2rem;
 
 // ===================================
 // Border Radius

--- a/src/alto-ui/scss/variables.scss
+++ b/src/alto-ui/scss/variables.scss
@@ -129,12 +129,12 @@ $pink: $pink-60 !default;
 
 $coolgrey-90: #192328 !default;
 $coolgrey-80: #333c48 !default;
-$coolgrey-70: #3f4f5e !default;
-$coolgrey-60: #4f6376 !default;
-$coolgrey-50: #758fa3 !default;
+$coolgrey-70: #495866 !default;
+$coolgrey-60: #66778a !default;
+$coolgrey-50: #8398a8 !default;
 $coolgrey-40: #a3b5c6 !default;
 $coolgrey-30: #bfcedd !default;
-$coolgrey-20: #dae4ed !default;
+$coolgrey-20: #e0e9f1 !default;
 $coolgrey-10: #f8f9fb !default;
 
 $grey-90: #242424 !default;


### PR DESCRIPTION
Button redesign:

- Reworked button heights: 1.5rem, 1.75rem, and 2rem heights for small, default, and large buttons respectively.
- New design for flat buttons
- Input heights tweaked to match default button height
- Switch input height adjusted as well