### PR TITLE
fixes datagrid resize

### DIFF
--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -364,7 +364,7 @@ class Datagrid extends React.PureComponent {
   }
 
   renderResizer() {
-    const { target, container, parent, resizing } = this.state.resizer;
+    const { target, container, parent, resizing, column } = this.state.resizer;
 
     return (
       <DatagridResizer
@@ -373,7 +373,7 @@ class Datagrid extends React.PureComponent {
         handleHeight={target.height}
         height={container.bottom - target.top}
         maxLeft={parent.left + 64}
-        maxRight={container.right}
+        maxRight={column && column.frozen ? container.right - 64 : container.right}
         onStart={this.handleStartResize}
         onStop={this.handleStopResize}
         resizing={resizing}

--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
@@ -4,6 +4,7 @@
   display: none;
   margin: 0;
   flex: 1;
+  min-width: 0;
 
   &--number,
   &--percentage,


### PR DESCRIPTION
- limit resize of frozen area in order to not block scrollable area
- crop dropdowns if columns is too thin