### PR TITLE
Create a Portal component + use it in Overlay

### DIFF
--- a/src/alto-ui/Overlay/Overlay.js
+++ b/src/alto-ui/Overlay/Overlay.js
@@ -1,7 +1,8 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import FocusTrap from 'focus-trap-react';
+import Portal from '../Portal';
 
 import './Overlay.scss';
 
@@ -119,7 +120,7 @@ class Overlay extends React.PureComponent {
   render() {
     const { open, children, blocking, inert, className } = this.props;
     return (
-      <Fragment>
+      <Portal display={open}>
         {open && blocking && <div className={classnames('Overlay__overlay', className)} />}
         <div ref={this.contentRef} aria-hidden={!open || inert} className="Overlay">
           {blocking ? (
@@ -134,7 +135,7 @@ class Overlay extends React.PureComponent {
             children
           )}
         </div>
-      </Fragment>
+      </Portal>
     );
   }
 }

--- a/src/alto-ui/Portal.js
+++ b/src/alto-ui/Portal.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+class Portal extends React.PureComponent {
+  constructor() {
+    super();
+
+    this.el = document.createElement('div');
+  }
+
+  componentDidMount() {
+    if (this.props.display) {
+      this.mount();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.display && !this.props.display) {
+      this.unmount();
+    }
+    if (!prevProps.display && this.props.display) {
+      this.mount();
+    }
+  }
+
+  componentWillUnmount() {
+    this.unmount();
+  }
+
+  getRoot() {
+    const { root } = this.props;
+    return (
+      (typeof root === 'string' && document.querySelector(root)) ||
+      (root && typeof root.appendChild === 'function' && root) ||
+      document.body
+    );
+  }
+
+  mount() {
+    this.unmount();
+    this.root = this.getRoot();
+    this.root.appendChild(this.el);
+  }
+
+  unmount() {
+    if (this.root) {
+      this.root.removeChild(this.el);
+      this.root = null;
+    }
+  }
+
+  render() {
+    return ReactDOM.createPortal(this.props.children, this.el);
+  }
+}
+
+Portal.defaultProps = {
+  display: true,
+};
+
+Portal.propTypes = {
+  root: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  children: PropTypes.any,
+  display: PropTypes.bool,
+};
+
+export default Portal;


### PR DESCRIPTION
Portal will render children in a React Portal => outside of the default root dom node. If no root is provided, it will append the content at the end of the body.