### PR TITLE
Create a OverlayContext to disable parent overlays

### DIFF
--- a/src/alto-ui/Overlay/Overlay.js
+++ b/src/alto-ui/Overlay/Overlay.js
@@ -51,6 +51,7 @@ class Overlay extends React.PureComponent {
   componentWillUnmount() {
     this.removeCloseEventListener();
     clearTimeout(this.closingTimeout);
+    this.props.removeOverlay();
   }
 
   contains(node) {
@@ -61,6 +62,7 @@ class Overlay extends React.PureComponent {
   }
 
   open() {
+    this.props.pushOverlay();
     this.addCloseEventListener();
     if (this.props.openFocusTargetId) {
       focusId(this.props.openFocusTargetId);
@@ -68,6 +70,7 @@ class Overlay extends React.PureComponent {
   }
 
   close() {
+    this.props.removeOverlay();
     this.removeCloseEventListener();
     if (this.props.closeFocusTargetId) {
       focusId(this.props.closeFocusTargetId);
@@ -144,7 +147,6 @@ Overlay.displayName = 'Overlay';
 
 Overlay.defaultProps = {
   blocking: false,
-  inert: false,
 };
 
 Overlay.propTypes = {
@@ -155,8 +157,10 @@ Overlay.propTypes = {
   closeFocusTargetId: PropTypes.string,
   open: PropTypes.bool.isRequired,
   blocking: PropTypes.bool,
-  inert: PropTypes.bool,
+  inert: PropTypes.bool.isRequired,
   include: PropTypes.object,
+  pushOverlay: PropTypes.func.isRequired,
+  removeOverlay: PropTypes.func.isRequired,
 };
 
 export default Overlay;

--- a/src/alto-ui/Overlay/OverlayContainer.js
+++ b/src/alto-ui/Overlay/OverlayContainer.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Overlay from './Overlay';
+
+const OverlayContext = React.createContext();
+
+const noop = () => {};
+
+class OverlayContainer extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      listOfChilrenOverlays: [this],
+    };
+
+    this.pushOverlay = this.pushOverlay.bind(this);
+    this.pushOverlayInContext = this.pushOverlayInContext.bind(this);
+    this.removeOverlayFromContext = noop;
+  }
+
+  getCurrentFromState() {
+    return this.state.listOfChilrenOverlays.slice(-1)[0];
+  }
+
+  pushOverlay(overlay) {
+    this.setState(({ listOfChilrenOverlays }) => ({
+      listOfChilrenOverlays: [...listOfChilrenOverlays, overlay],
+    }));
+    return () =>
+      this.setState(({ listOfChilrenOverlays }) => ({
+        listOfChilrenOverlays: listOfChilrenOverlays.filter(o => o !== overlay),
+      }));
+  }
+
+  pushOverlayInContext() {
+    const { context } = this.props;
+    this.removeOverlayFromContext = context ? context.pushOverlay(this) : noop;
+  }
+
+  renderOverlay() {
+    const { context, inert, ...props } = this.props;
+
+    const currentOverlay = context ? context.current : this.getCurrentFromState();
+
+    return (
+      <Overlay
+        {...props}
+        pushOverlay={this.pushOverlayInContext}
+        removeOverlay={this.removeOverlayFromContext}
+        inert={inert || currentOverlay !== this}
+      />
+    );
+  }
+
+  render() {
+    const { context } = this.props;
+    if (context) return this.renderOverlay();
+
+    // No context: let's provide one to futur overlay children
+
+    return (
+      <OverlayContext.Provider
+        value={{
+          pushOverlay: this.pushOverlay,
+          current: this.getCurrentFromState(),
+        }}
+      >
+        {this.renderOverlay()}
+      </OverlayContext.Provider>
+    );
+  }
+}
+
+OverlayContainer.displayName = 'OverlayContainer';
+
+OverlayContainer.defaultProps = {
+  inert: false,
+};
+
+OverlayContainer.propTypes = {
+  context: PropTypes.shape({
+    pushOverlay: PropTypes.func.isRequired,
+    current: PropTypes.object.isRequired,
+  }),
+  inert: PropTypes.bool,
+};
+
+export default props => (
+  <OverlayContext.Consumer>
+    {context => <OverlayContainer {...props} context={context} />}
+  </OverlayContext.Consumer>
+);

--- a/src/alto-ui/Overlay/index.js
+++ b/src/alto-ui/Overlay/index.js
@@ -1,1 +1,1 @@
-export { default } from './Overlay';
+export { default } from './OverlayContainer';

--- a/src/alto-ui/scss/variables.scss
+++ b/src/alto-ui/scss/variables.scss
@@ -267,17 +267,17 @@ $size-touch: 3rem !default;
 // Z-index
 
 $z-index-focusable-focused: 20000 !default;
+$z-index-tooltip: 15000 !default;
 $z-index-toast: 12000 !default;
 $z-index-alert: 12000 !default;
-$z-index-dialog: 11000 !default;
-$z-index-modal: 10000 !default;
 $z-index-overlay: 9000 !default;
+$z-index-dialog: $z-index-overlay !default;
+$z-index-modal: $z-index-overlay !default;
+$z-index-popover: $z-index-overlay !default;
+$z-index-datepicker: $z-index-overlay !default;
+$z-index-popup: $z-index-overlay !default;
 $z-index-navbar: 7000 !default;
 $z-index-sidebar: 6000 !default;
-$z-index-popover: 5000 !default;
-$z-index-datepicker: 5000 !default;
-$z-index-popup: 3000 !default;
-$z-index-tooltip: 3000 !default;
 $z-index-content: 1000 !default;
 $z-index-default: 1 !default;
 


### PR DESCRIPTION
The idea is that if an overlay is created inside an another one (a dropdown inside a modal for example) , it will disable (forcing `inert` prop) its parent overlays. So you can only close one overlay at a time (the last open one).