### PR TITLE
34695 - recalculate height of freeze table on window.resize event

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
       "exports": 'always-multiline',
       "functions": "ignore",
     }],
+    "linebreak-style": 0,
     "import/prefer-default-export": 0,
     "react/forbid-prop-types": 0,
     "react/no-danger": 0,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -120,7 +120,7 @@ class Datagrid extends React.PureComponent {
       }
       this.setState({ loaded: true });
     }, 0);
-    this.handleWindowResize();
+    this.addWindowResizeListener();
   }
 
   componentDidUpdate() {
@@ -179,7 +179,7 @@ class Datagrid extends React.PureComponent {
     }
   }
 
-  handleWindowResize() {
+  addWindowResizeListener() {
     window.addEventListener('resize', this.trackDimensions);
   }
 

--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -101,7 +101,7 @@ class Datagrid extends React.PureComponent {
     this.handleToggleGroup = this.handleToggleGroup.bind(this);
     this.handleStopResize = this.handleStopResize.bind(this);
     this.handleStartResize = this.handleStartResize.bind(this);
-    this.trackDimensions = this.trackDimensions.bind(this);
+    this.trackDimensions = debounce(this.trackDimensions.bind(this), WINDOW_RESIZE_DEBOUNCE);
 
     this.containerRef = React.createRef();
   }
@@ -117,10 +117,10 @@ class Datagrid extends React.PureComponent {
         this.staticRowsNode.scrollLeft = 0;
         this.staticRowsNode.scrollTop = 0;
         this.trackDimensions();
-        this.handleWindowResize();
       }
       this.setState({ loaded: true });
     }, 0);
+    this.handleWindowResize();
   }
 
   componentDidUpdate() {
@@ -180,7 +180,7 @@ class Datagrid extends React.PureComponent {
   }
 
   handleWindowResize() {
-    window.addEventListener('resize', debounce(this.trackDimensions, WINDOW_RESIZE_DEBOUNCE));
+    window.addEventListener('resize', this.trackDimensions);
   }
 
   handleToggleGroup(groupId) {

--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash.debounce';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
@@ -18,6 +19,7 @@ import DatagridResizer from './components/DatagridResizer';
 import './Datagrid.scss';
 
 const CHECKBOX_WIDTH = 40;
+const WINDOW_RESIZE_DEBOUNCE = 100;
 
 const DEFAULT_LABELS = {
   errorFormula: 'There is an error in formula',
@@ -99,6 +101,7 @@ class Datagrid extends React.PureComponent {
     this.handleToggleGroup = this.handleToggleGroup.bind(this);
     this.handleStopResize = this.handleStopResize.bind(this);
     this.handleStartResize = this.handleStartResize.bind(this);
+    this.trackDimensions = this.trackDimensions.bind(this);
 
     this.containerRef = React.createRef();
   }
@@ -114,6 +117,7 @@ class Datagrid extends React.PureComponent {
         this.staticRowsNode.scrollLeft = 0;
         this.staticRowsNode.scrollTop = 0;
         this.trackDimensions();
+        this.handleWindowResize();
       }
       this.setState({ loaded: true });
     }, 0);
@@ -121,6 +125,10 @@ class Datagrid extends React.PureComponent {
 
   componentDidUpdate() {
     this.trackDimensions();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.trackDimensions);
   }
 
   getContext() {
@@ -170,6 +178,11 @@ class Datagrid extends React.PureComponent {
       }
     }
   }
+
+  handleWindowResize() {
+    window.addEventListener('resize', debounce(this.trackDimensions, WINDOW_RESIZE_DEBOUNCE));
+  }
+
   handleToggleGroup(groupId) {
     const stateGroupId = this.state.collapsedGroups[groupId];
     const collapsedGroups = {


### PR DESCRIPTION
Added also the .prettierrc config and .eslint line-break style to avoid Mac - Windows line break conflict