### PR TITLE
remove default right number input text align

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
@@ -69,6 +69,7 @@ class DatagridCellInput extends React.Component {
           ...sharedProps,
           locale: context.locale,
           precision: column.precision,
+          right: true,
           disableThousandSeparator: column.disableThousandSeparator,
           ...inputProps,
         };

--- a/src/alto-ui/Form/InputNumber/InputNumber.js
+++ b/src/alto-ui/Form/InputNumber/InputNumber.js
@@ -83,7 +83,6 @@ class InputNumber extends React.Component {
         ref={forwardedRef}
         {...rest}
         type="text"
-        right
         value={this.state.display}
         onChange={this.handleChange}
         onFocus={this.handleFocus}


### PR DESCRIPTION
According to @andymcfee decision, input number shouldn't have forced right align by default. That align should be set only where is needed