### PR TITLE
Feature/date picker placeholder

### DIFF
--- a/src/alto-ui/Form/DatePicker/DatePicker.js
+++ b/src/alto-ui/Form/DatePicker/DatePicker.js
@@ -83,18 +83,18 @@ class DatePicker extends React.Component {
   }
 
   formatTextfieldDate() {
-    const { open } = this.state;
+    // const { open } = this.state; // Uncomment when we enhance for typing in datefield
     const { format, displayFormat } = this.props;
     const date = this.getDate();
 
     if (!date) return '';
-    if (open) return date.toFormat(format);
+    //if (open) return date.toFormat(format); // Uncomment when we enhance for typing in datefield
 
     return date.toFormat(displayFormat || format);
   }
 
   render() {
-    const { id, small, large, frozen } = this.props;
+    const { id, small, large, frozen, placeholder } = this.props;
     const { open } = this.state;
     const date = this.getDate();
 
@@ -102,7 +102,7 @@ class DatePicker extends React.Component {
       <div className={classnames('DatePicker', this.props.className)}>
         <TextField
           ref={this.getInputRef()}
-          placeholder={this.props.format}
+          placeholder={placeholder}
           label={this.props.label}
           hideLabel={this.props.hideLabel}
           {...this.props.inputProps}
@@ -147,6 +147,7 @@ DatePicker.displayName = 'DatePicker';
 DatePicker.defaultProps = {
   inputProps: {},
   format: 'dd/MM/yyyy',
+  placeholder: '',
   displayFormat: 'dd LLL yyyy',
 };
 
@@ -156,6 +157,7 @@ DatePicker.propTypes = {
   className: PropTypes.string,
   children: PropTypes.any,
   format: PropTypes.string,
+  placeholder: PropTypes.string,
   displayFormat: PropTypes.string,
   readOnly: PropTypes.bool,
   onChange: PropTypes.func.isRequired,

--- a/src/alto-ui/Form/DatePicker/DatePicker.js
+++ b/src/alto-ui/Form/DatePicker/DatePicker.js
@@ -88,7 +88,7 @@ class DatePicker extends React.Component {
     const date = this.getDate();
 
     if (!date) return '';
-    //if (open) return date.toFormat(format); // Uncomment when we enhance for typing in datefield
+    // if (open) return date.toFormat(format); // Uncomment when we enhance for typing in datefield
 
     return date.toFormat(displayFormat || format);
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/938464/54427077-b81a5a00-4719-11e9-8a4e-0b481bd1d053.png)

Updating the UX of the datepicker to match the current functionality:
- Removed the placeholder (dd/MM/yyyy) since the purpose of the placeholder is to show user the format they need to use to type, but there is currently not ability to type in this input
- Temporarily disabled the swapping of the formatted date between focus and non-focused state.  Previously, the date would display as 15 March 2019 until the input is focused and it would change to 15/03/2019, but again, since there is not typing allowed yet, this swapping did not make sense.