### PR TITLE
add useFocusInOut hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lodash.isnumber": "^3.0.3",
     "lodash.omit": "^4.5.0",
     "lodash.range": "^3.2.0",
+    "lodash.throttle": "^4.1.1",
     "luxon": "^1.0.0",
     "react-beautiful-dnd": "^10.0.4",
     "react-day-picker": "^7.1.4",

--- a/src/alto-ui/hooks/useFocusInOut.js
+++ b/src/alto-ui/hooks/useFocusInOut.js
@@ -1,0 +1,36 @@
+import { useState, useRef, useEffect } from 'react';
+import throttle from 'lodash.throttle';
+
+import useEventListener from './useEventListener';
+
+const contains = (target, refs) => refs.some(ref => ref.current && ref.current.contains(target));
+
+export default function useFocusInOut(cb, ...refs) {
+  const [isFocused, setFocus] = useState(false);
+  const documentRef = useRef(document);
+
+  const setFocusBatched = throttle(setFocus, 200, {
+    leading: false,
+  });
+
+  function focusInlistener(e) {
+    setFocusBatched(contains(e.target, refs));
+  }
+
+  function focusOutlistener(e) {
+    if (contains(e.target, refs)) {
+      setFocusBatched(false);
+    }
+  }
+
+  useEventListener(documentRef, 'focusin', focusInlistener);
+  useEventListener(documentRef, 'focusout', focusOutlistener);
+  // using capture will allow to detect the click on a node that will disapear
+  // after this click -> remove an item of list for example by clicking on this item
+  useEventListener(documentRef, 'mousedown', focusInlistener, true);
+  useEventListener(documentRef, 'click', focusInlistener, true);
+  useEffect(() => {
+    if (typeof cb === 'function') cb(isFocused);
+  }, [isFocused]);
+  return isFocused;
+}


### PR DESCRIPTION
- take at least 2 param: a callback, and at least one ref (other params is for optional additionnal refs)
- call the callback each time the ref(s) receive the focus or loose it (works with children)
- usefull to create a element that can have a "active" state
- return focuses state (callback is not mandatory, can be pass as null and you can use just the returned state) 