### PR TITLE
BQM-135 Fix number input shrinking on wide columns in grids

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
@@ -35,8 +35,6 @@
     }
   }
 
-
-
   &--comfortable {
     .textfield {
       height: $height-large;

--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.scss
@@ -16,6 +16,11 @@
     }
   }
 
+  //TODO refactor this to not nest
+  &.InputNumber {
+    max-width: none;
+  }
+
   &--number,
   &--percentage,
   &--int,
@@ -28,8 +33,9 @@
       font-size: $font-size-small;
       box-shadow: none;
     }
-
   }
+
+
 
   &--comfortable {
     .textfield {


### PR DESCRIPTION
On focus, the number inputs in grids with wide columns would shrink. 

#### BEFORE
![image](https://user-images.githubusercontent.com/938464/56353872-b2111080-61d2-11e9-989e-b8ce629136c4.png)


#### AFTER
![image](https://user-images.githubusercontent.com/938464/56353795-7bd39100-61d2-11e9-8779-0715573d673d.png)