### PR TITLE
Fix misalignment of checkboxes in grouped grids

### DIFF
--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -289,7 +289,7 @@ class Datagrid extends React.PureComponent {
         {cells => (
           <Fragment>
             {hasCheckbox && (
-              <div className={bemClass('DataGrid__row-checkbox', { ...modifiers, header: true })} />
+              <div className={bemClass('DataGrid__row-checkbox', { ...modifiers, header: true, summary: true })} />
             )}
             {cells}
           </Fragment>

--- a/src/alto-ui/Datagrid/Datagrid.scss
+++ b/src/alto-ui/Datagrid/Datagrid.scss
@@ -116,8 +116,6 @@
   width: $height-datagrid-default;
   border-bottom: 1px solid $coolgrey-20;
 
-
-
   &--compact {
     height: $height-datagrid-compact;
   }
@@ -129,6 +127,7 @@
   &--header {
     background-color: $white;
     height: $height-datagrid-header-default;
+    
     &.DataGrid__row-checkbox--compact {
       height: $height-datagrid-header-compact;
     }
@@ -137,8 +136,6 @@
       height: $height-datagrid-header-comfortable;
     }
   }
-
-
 }
 
 @media all and (-ms-high-contrast: none) {

--- a/src/alto-ui/Datagrid/Datagrid.scss
+++ b/src/alto-ui/Datagrid/Datagrid.scss
@@ -116,17 +116,29 @@
   width: $height-datagrid-default;
   border-bottom: 1px solid $coolgrey-20;
 
-  &--header {
-    background-color: $white;
-  }
 
-  &--compact:not(.DataGrid__row-checkbox--header) {
+
+  &--compact {
     height: $height-datagrid-compact;
   }
 
   &--comfortable {
     height: $height-datagrid-comfortable;
   }
+
+  &--header {
+    background-color: $white;
+    height: $height-datagrid-header-default;
+    &.DataGrid__row-checkbox--compact {
+      height: $height-datagrid-header-compact;
+    }
+
+    &.DataGrid__row-checkbox--comfortable {
+      height: $height-datagrid-header-comfortable;
+    }
+  }
+
+
 }
 
 @media all and (-ms-high-contrast: none) {

--- a/src/alto-ui/Datagrid/Datagrid.scss
+++ b/src/alto-ui/Datagrid/Datagrid.scss
@@ -127,7 +127,7 @@
   &--header {
     background-color: $white;
     height: $height-datagrid-header-default;
-    
+
     &.DataGrid__row-checkbox--compact {
       height: $height-datagrid-header-compact;
     }
@@ -136,6 +136,19 @@
       height: $height-datagrid-header-comfortable;
     }
   }
+
+  &--summary {
+    height: $height-datagrid-default;
+
+    &.DataGrid__row-checkbox--compact {
+      height: $height-datagrid-default;
+    }
+
+    &.DataGrid__row-checkbox--comfortable {
+      height: $height-datagrid-comfortable;
+    }
+  }
+
 }
 
 @media all and (-ms-high-contrast: none) {


### PR DESCRIPTION
- Fixed misalignment of grid rows caused by the grouped summary row's checkbox placeholder
- Fixed all three row density size settings
- Fixed issue where the summary row checkbox placeholder was sizing incorrectly at `default` and `compact` density settings

### OLD
![image](https://user-images.githubusercontent.com/938464/56573375-3abbf200-65c1-11e9-9da8-74ea26a75d19.png)

### NEW
![image](https://user-images.githubusercontent.com/938464/56573332-24159b00-65c1-11e9-8b6b-eec425653a79.png)
