### PR TITLE
bugfix Datagrid : manage onOpen event on list

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
@@ -49,15 +49,24 @@ class DatagridCellInput extends React.Component {
     const { type, context, column, inputProps } = this.props;
 
     const sharedProps = this.getSharedProps();
+
     switch (type) {
       case 'list':
       case 'select':
-      case 'boolean':
         return {
           ...sharedProps,
           onBlur: undefined,
           onFocus: undefined,
           onChange: this.handleChangeFromOverlay,
+          onOpen: this.handleStartEditing,
+          clearable: true,
+          ...inputProps,
+        };
+      case 'boolean':
+        return {
+          ...sharedProps,
+          onBlur: undefined,
+          onFocus: undefined,
           ...inputProps,
         };
       case 'number':


### PR DESCRIPTION
Previous PR remove two props on list:
```
- onOpen: this.handleStartEditing,
- clearable: true,
```

