### PR TITLE
Ensure Quill css can be overridden

### DIFF
--- a/src/alto-ui/Form/RichTextEditor/RichTextEditor.js
+++ b/src/alto-ui/Form/RichTextEditor/RichTextEditor.js
@@ -4,10 +4,6 @@ import Editor, { Quill } from 'react-quill';
 import MagicUrl from 'quill-magic-url';
 import 'quill-mention';
 
-import 'react-quill/dist/quill.core.css';
-import 'react-quill/dist/quill.snow.css';
-import 'react-quill/dist/quill.bubble.css';
-
 import { bemClass } from '../../helpers/bem';
 import context from './context';
 import HTMLBlock from '../../HTMLBlock/HTMLBlock';

--- a/src/alto-ui/HTMLBlock/HTMLBlock.js
+++ b/src/alto-ui/HTMLBlock/HTMLBlock.js
@@ -3,10 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { sanitize } from 'dompurify';
 
-import 'react-quill/dist/quill.core.css';
-
 import { bemClass } from '../helpers/bem';
-
 import './HTMLBlock.scss';
 
 const renderMentions = (ref, renderMention) => {

--- a/src/alto-ui/scss/index.scss
+++ b/src/alto-ui/scss/index.scss
@@ -1,4 +1,5 @@
-@import "./inc";
+@import './inc';
 
-@import "./reset";
-@import "./base";
+@import './reset';
+@import './libs';
+@import './base';

--- a/src/alto-ui/scss/libs.scss
+++ b/src/alto-ui/scss/libs.scss
@@ -1,0 +1,7 @@
+// using url(...) in order ot ensure it will be be loaded first
+// and can be then overridden
+// it seems to be a bug introduced in webpack 3 or 4
+// solution found here: https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/200#issuecomment-379549528
+@import url('~react-quill/dist/quill.core.css');
+@import url('~react-quill/dist/quill.snow.css');
+@import url('~react-quill/dist/quill.bubble.css');


### PR DESCRIPTION
Move Quill css files to an external scss/libs file to ensure the will be loaded once and first.
No visual changes.