### PR TITLE
Create a context for HTMLBlock

### DIFF
--- a/src/alto-ui/HTMLBlock/context.js
+++ b/src/alto-ui/HTMLBlock/context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext({});


### PR DESCRIPTION
The goal is to allow users to pass the same props more easily to all HTMLBlock in the tree. Same renderMentions for example. It's like a `shared props provider`.