### PR TITLE
bugfix/Fix default check for checkbox on data grid

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
@@ -67,7 +67,6 @@ class DatagridCellInput extends React.Component {
           ...sharedProps,
           onBlur: undefined,
           onFocus: undefined,
-          defaultChecked: !!sharedProps.value,
           ...inputProps,
         };
       case 'number':

--- a/src/alto-ui/Input/Input.js
+++ b/src/alto-ui/Input/Input.js
@@ -87,8 +87,8 @@ const Input = React.forwardRef((props, ref) => {
     return null;
   }
 
-  const { type, inputRef, debounced, ...otherProps } = props;
-
+  const { type, inputRef, debounced, checked, ...otherProps } = props;
+  const { small, ...checkboxProps } = otherProps;
   const sharedProps = {
     ref,
     onChange,
@@ -110,7 +110,7 @@ const Input = React.forwardRef((props, ref) => {
     case 'select':
       return <Select {...otherProps} {...sharedProps} />;
     case 'boolean':
-      return <CheckBox {...otherProps} checked={props.value} {...sharedProps} />;
+      return <CheckBox {...checkboxProps} checked={!!checkboxProps.value} {...sharedProps} />;
     case 'textarea':
       return <TextArea {...otherProps} {...sharedProps} />;
     case 'richtext':


### PR DESCRIPTION
Fix technical issue with default check state for checkbox

Main cause of this change was an Warning: 
```
Warning: ForwardRef contains an input of type checkbox with both checked and defaultChecked props.
Input elements must be either controlled or uncontrolled (specify either the checked prop, or the
defaultChecked prop, but not both). Decide between using a controlled or uncontrolled input element
and remove one of these props.
```