### PR TITLE
Add Actions and Group

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -50,6 +50,7 @@ addDecorator(withKnobs);
 addDecorator(story => <Root>{story()}</Root>);
 
 function loadStories() {
+  require('../src/alto-ui/Actions/story');
   require('../src/alto-ui/Alert/story');
   require('../src/alto-ui/Aside/story');
   require('../src/alto-ui/Avatar/story');

--- a/src/alto-ui/Actions/Actions.js
+++ b/src/alto-ui/Actions/Actions.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { bemClass } from '../helpers/bem';
+import Group from '../Group';
+import Dropdown from '../Dropdown';
+import OptionsIcon from '../Icons/Options';
+
+import './Actions.scss';
+
+function Actions({ className, id, items, max, onClick }) {
+  if (!items || !items.length) return null;
+  const handleClick = action => (typeof onClick === 'function' ? () => onClick(action) : undefined);
+  if (items.length > max) {
+    return (
+      <Dropdown
+        className={bemClass('Actions', {}, className)}
+        end
+        id={id}
+        renderTrigger={(toggle, active, ref) => (
+          <div ref={ref}>
+            <OptionsIcon onClick={toggle} active={active} />
+          </div>
+        )}
+        selected={items.filter(action => action.active).map(action => action.key)}
+        items={items.map(action => ({
+          key: action.key,
+          title: action.title,
+          onClick: action.onClick || handleClick(action),
+        }))}
+      />
+    );
+  }
+  return (
+    <Group className={bemClass('Actions', {}, className)} splitted items={items} itemKey="key">
+      {action => {
+        const {
+          key,
+          title,
+          Icon: oldIconNameToRemove,
+          icon: newIconNameToRefactor,
+          ...iconProps
+        } = action;
+        const Icon = oldIconNameToRemove || newIconNameToRefactor;
+        return (
+          <Icon
+            title={title}
+            outline={!iconProps.active}
+            onClick={handleClick(action)}
+            {...iconProps}
+          />
+        );
+      }}
+    </Group>
+  );
+}
+
+Actions.displayName = 'Actions';
+
+Actions.defaultProps = {
+  max: 3,
+};
+
+Actions.propTypes = {
+  id: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  max: PropTypes.number,
+  onClick: PropTypes.func,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      icon: PropTypes.any,
+      title: PropTypes.string,
+      onClick: PropTypes.func,
+      active: PropTypes.bool,
+    }).isRequired
+  ),
+};
+
+export default Actions;

--- a/src/alto-ui/Actions/Actions.scss
+++ b/src/alto-ui/Actions/Actions.scss
@@ -1,0 +1,1 @@
+@import '../scss/inc';

--- a/src/alto-ui/Actions/index.js
+++ b/src/alto-ui/Actions/index.js
@@ -1,0 +1,1 @@
+export { default } from './Actions';

--- a/src/alto-ui/Actions/story.js
+++ b/src/alto-ui/Actions/story.js
@@ -1,0 +1,66 @@
+/* eslint-disable import/no-extraneous-dependencies, react/prop-types */
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import centered from '@storybook/addon-centered';
+import { number } from '@storybook/addon-knobs';
+
+import Pencil from '../Icons/Pencil';
+import Duplicate from '../Icons/Duplicate';
+import Trash from '../Icons/Trash';
+import Cog from '../Icons/Cog';
+
+import ActionsStateLess from './Actions';
+
+function Actions(props) {
+  const [selection, setSelection] = useState({});
+  return (
+    <ActionsStateLess
+      {...props}
+      items={props.items.map(elt => ({
+        ...elt,
+        active: selection[elt.key],
+        onClick: () => setSelection({ [elt.key]: !selection[elt.key] }),
+      }))}
+    />
+  );
+}
+
+const items = [
+  {
+    key: '1',
+    icon: Pencil,
+    title: 'Edit',
+    onClick: () => {},
+  },
+  {
+    key: '2',
+    icon: Duplicate,
+    title: 'Duplicate',
+    onClick: () => {},
+  },
+  {
+    key: '3',
+    icon: Trash,
+    title: 'Delete',
+    onClick: () => {},
+  },
+  {
+    key: '4',
+    icon: Cog,
+    title: 'Settings',
+    onClick: () => {},
+  },
+];
+
+storiesOf('Actions', module)
+  .addDecorator(centered)
+  .addWithJSX('overview', () => (
+    <Actions
+      id="actions"
+      max={number('max', 3, { min: 0, max: 4, step: 1 })}
+      items={items.slice(
+        0,
+        number('How many actions ?', 3, { range: true, min: 0, max: 4, step: 1 })
+      )}
+    />
+  ));

--- a/src/alto-ui/Group/CleanGroupContext.js
+++ b/src/alto-ui/Group/CleanGroupContext.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import context from './context';
+
+function CleanGroupContext({ children }) {
+  return <context.Provider value={undefined}>{children}</context.Provider>;
+}
+
+CleanGroupContext.propTypes = {
+  children: PropTypes.any,
+};
+
+export default CleanGroupContext;

--- a/src/alto-ui/Group/Group.js
+++ b/src/alto-ui/Group/Group.js
@@ -1,0 +1,35 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+import { bemClass } from '../helpers/bem';
+import './Group.scss';
+import GroupItem from './GroupItem';
+
+const renderGroupItem = (itemKey, column, splitted, children) => (item, index, items) => (
+  <GroupItem key={item[itemKey] || item} items={items} column={column} splitted={splitted}>
+    {children(item, index, items)}
+  </GroupItem>
+);
+
+const Group = forwardRef(
+  ({ itemKey, className, children, items, column, splitted, ...props }, ref) => (
+    <ul {...props} ref={ref} className={bemClass('Group', { column, splitted }, className)}>
+      {typeof children === 'function'
+        ? items.map(renderGroupItem(itemKey, column, splitted, children))
+        : children}
+    </ul>
+  )
+);
+
+Group.defaultProps = {
+  itemKey: 'id',
+};
+
+Group.displayName = 'Group';
+
+Group.propTypes = {
+  items: PropTypes.array.isRequired,
+  children: PropTypes.any,
+};
+
+export default Group;

--- a/src/alto-ui/Group/Group.scss
+++ b/src/alto-ui/Group/Group.scss
@@ -1,0 +1,14 @@
+@import '../scss/inc';
+
+.Group {
+  display: flex;
+  list-style: none;
+
+  &--column {
+    flex-direction: column;
+  }
+
+  &--splitted > *:not(:first-child) {
+    margin-left: $spacing-small;
+  }
+}

--- a/src/alto-ui/Group/GroupItem.js
+++ b/src/alto-ui/Group/GroupItem.js
@@ -1,0 +1,30 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+import context from './context';
+import './Group.scss';
+
+const GroupItem = forwardRef(({ items, index, column, splitted, ...props }, ref) => (
+  <context.Provider
+    value={{
+      first: index === 0,
+      last: index === items.length - 1,
+      row: !column,
+      column: !!column,
+      splitted: !!splitted,
+      stacked: !splitted,
+    }}
+  >
+    <li {...props} ref={ref} />
+  </context.Provider>
+));
+
+GroupItem.defaultProps = {};
+
+GroupItem.displayName = 'GroupItem';
+
+GroupItem.propTypes = {
+  items: PropTypes.array.isRequired,
+};
+
+export default GroupItem;

--- a/src/alto-ui/Group/context.js
+++ b/src/alto-ui/Group/context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext(undefined);

--- a/src/alto-ui/Group/index.js
+++ b/src/alto-ui/Group/index.js
@@ -1,0 +1,1 @@
+export { default } from './Group';


### PR DESCRIPTION
Group is used to create a "Group" context. Then if you create a component that can be grouped, you will be able to guess if you are in a group and in which position. Needed for list, button group...

Actions is a group of icons that if you get more than the defined max number ut turns into a dropdown.

max: 3, actions: 2 | max: 3, actions: 3 | max: 2, actions: 3
-|-|-
![image](https://user-images.githubusercontent.com/5002260/59858076-91a03680-937a-11e9-8dee-dd4cfbca3186.png) | ![image](https://user-images.githubusercontent.com/5002260/59858101-9cf36200-937a-11e9-9ced-be54b689441f.png) | ![image](https://user-images.githubusercontent.com/5002260/59858176-c0b6a800-937a-11e9-8da9-3e166914c121.png)

