### PR TITLE
Better default "itemKey" + stories of List

### DIFF
--- a/src/alto-ui/Group/Group.js
+++ b/src/alto-ui/Group/Group.js
@@ -2,11 +2,12 @@ import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { bemClass } from '../helpers/bem';
-import './Group.scss';
+import getDefaultItemKey from '../helpers/getItemKey';
 import GroupItem from './GroupItem';
+import './Group.scss';
 
 const renderGroupItem = (itemKey, column, splitted, children) => (item, index, items) => (
-  <GroupItem key={item[itemKey] || item} items={items} column={column} splitted={splitted}>
+  <GroupItem key={itemKey(item) || item} items={items} column={column} splitted={splitted}>
     {children(item, index, items)}
   </GroupItem>
 );
@@ -15,19 +16,18 @@ const Group = forwardRef(
   ({ itemKey, className, children, items, column, splitted, ...props }, ref) => (
     <ul {...props} ref={ref} className={bemClass('Group', { column, splitted }, className)}>
       {typeof children === 'function'
-        ? items.map(renderGroupItem(itemKey, column, splitted, children))
+        ? items.map(renderGroupItem(getDefaultItemKey(itemKey), column, splitted, children))
         : children}
     </ul>
   )
 );
 
-Group.defaultProps = {
-  itemKey: 'id',
-};
+Group.defaultProps = {};
 
 Group.displayName = 'Group';
 
 Group.propTypes = {
+  itemKey: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   items: PropTypes.array.isRequired,
   children: PropTypes.any,
 };

--- a/src/alto-ui/List/List.scss
+++ b/src/alto-ui/List/List.scss
@@ -11,8 +11,13 @@
   position: relative;
 
   &--active,
+  &--hover,
   &--clickable:hover {
     background-color: $blue-10;
+  }
+
+  &--active {
+    color: $blue;
   }
 }
 
@@ -20,11 +25,13 @@
   display: flex;
   padding: 0 $spacing-small;
   align-items: center;
-  min-height: 4rem;
+
+  &--small,
+  &--borderless {
+    padding: 0 $spacing-x-small;
+  }
 
   &--small {
-    min-height: 2rem;
-    padding: 0 $spacing-x-small;
     font-size: $font-size-small;
   }
 }
@@ -43,7 +50,8 @@
   min-width: 0;
   flex-shrink: 0;
 
-  &--small {
+  &--small,
+  &--borderless {
     padding: $spacing-x-small;
   }
 
@@ -86,6 +94,14 @@
 
     .List__item-row:hover & {
       visibility: visible;
+    }
+  }
+
+  &--media {
+    min-height: 4rem;
+
+    &.List__field--small {
+      min-height: 2rem;
     }
   }
 }

--- a/src/alto-ui/List/story/Backlog.js
+++ b/src/alto-ui/List/story/Backlog.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies, react/prop-types */
 import React, { useState } from 'react';
+import { boolean } from '@storybook/addon-knobs';
 
 import List from '../List';
 import Lightbulb from '../../Icons/Lightbulb';
@@ -62,11 +63,11 @@ function Backlog() {
   return (
     <List
       id="backlog"
-      small
       sortable
       active={({ selected }) => selected}
       items={items}
       onChange={xs => setItems(xs)}
+      small={boolean('small', false)}
       fields={[
         {
           key: 'selected',
@@ -94,7 +95,7 @@ function Backlog() {
           key: 'assignee',
           type: 'avatar',
           defaultValue: {},
-          props: ({ img, name }) => ({ src: img, tooltip: name }),
+          props: ({ img, name }) => ({ src: img, tooltip: name, small: true }),
         },
         {
           key: 'points',

--- a/src/alto-ui/List/story/Simple.js
+++ b/src/alto-ui/List/story/Simple.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/no-extraneous-dependencies, react/prop-types */
+import React from 'react';
+import { boolean } from '@storybook/addon-knobs';
+
+import List from '../List';
+
+function Simple() {
+  return (
+    <List
+      items={['One', 'Two', 'Tree', 'Four', 'Five']}
+      sortable={boolean('sortable', false)}
+      borderless={boolean('borderless', false)}
+      small={boolean('small', false)}
+    />
+  );
+}
+export default Simple;

--- a/src/alto-ui/List/story/SimpleDemo.js
+++ b/src/alto-ui/List/story/SimpleDemo.js
@@ -55,6 +55,7 @@ function SimpleDemo() {
         },
       ]}
       items={items}
+      active={item => item.config.active}
       onChange={xs => setItems(xs)}
       onClick={(field, item, setItem) => {
         switch (field.key) {

--- a/src/alto-ui/List/story/index.js
+++ b/src/alto-ui/List/story/index.js
@@ -4,14 +4,40 @@ import { storiesOf } from '@storybook/react';
 import centered from '@storybook/addon-centered';
 
 import SimpleDemo from './SimpleDemo';
+import Simple from './Simple';
 import Backlog from './Backlog';
 import NestedList from './NestedList';
 import Full from './Full';
+import List from '../List';
+import Button from '../../Button';
 
 storiesOf('List', module)
   .addDecorator(story => <div style={{ width: 800, maxWidth: '100%' }}>{story()}</div>)
   .addDecorator(centered)
-  .addWithJSX('Simple Demo', () => <SimpleDemo />)
+  .addWithJSX('Standard', () => <SimpleDemo />)
+  .addWithJSX('Simple', () => <Simple />)
   .addWithJSX('Backlog', () => <Backlog />)
-  .addWithJSX('NestedList', () => <NestedList />)
-  .addWithJSX('Full', () => <Full />);
+  .addWithJSX('Nested Auto', () => <NestedList />)
+  .addWithJSX('Full', () => <Full />)
+  .addWithJSX('Nested Custom', () => (
+    <List borderless items={['apple', 'orange', 'banana']}>
+      {item => (
+        <div style={{ padding: '5px 10px 20px 30px' }}>
+          <List
+            items={[...Array(3).keys()].map(n => `${item} ${n + 1}`)}
+            fields={child => [
+              { key: 'title', render: () => child, primary: true },
+              {
+                key: 'add',
+                render: () => (
+                  <Button small on>
+                    add
+                  </Button>
+                ),
+              },
+            ]}
+          />
+        </div>
+      )}
+    </List>
+  ));

--- a/src/alto-ui/Sortable/Sortable.js
+++ b/src/alto-ui/Sortable/Sortable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 
 import { bemClass } from '../helpers/bem';
+import getDefaultItemKey from '../helpers/getItemKey';
 import useUniqueKey from '../hooks/useUniqueKey';
 
 import './Sortable.scss';
@@ -43,6 +44,7 @@ const handleDragEnd = (instance, result) => {
 
 function Sortable(props) {
   const { className, children, items, itemIdKey, renderDraggable, renderDroppable } = props;
+  const itemKey = getDefaultItemKey(itemIdKey);
   const droppableId = useUniqueKey(props.id);
   const type = useUniqueKey(props.type);
   const instance = useRef({ propsByDroppableId: {} }).current;
@@ -72,8 +74,8 @@ function Sortable(props) {
             <Fragment>
               {items.map((item, index) => (
                 <Draggable
-                  key={item[itemIdKey]}
-                  draggableId={item[itemIdKey]}
+                  key={itemKey(item)}
+                  draggableId={itemKey(item)}
                   index={index}
                   isDragDisabled={!!props.isItemDisabled(item)}
                 >
@@ -138,7 +140,6 @@ function Sortable(props) {
 Sortable.displayName = 'Sortable';
 
 Sortable.defaultProps = {
-  itemIdKey: 'id',
   isItemDisabled: () => false,
   renderDroppable: props => <ul {...props} />,
   renderDraggable: props => <li {...props} />,
@@ -149,7 +150,7 @@ Sortable.propTypes = {
   type: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.func,
-  itemIdKey: PropTypes.string,
+  itemIdKey: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   items: PropTypes.array,
   // eslint-disable-next-line react/no-unused-prop-types
   onChange: PropTypes.func,

--- a/src/alto-ui/helpers/getItemKey.js
+++ b/src/alto-ui/helpers/getItemKey.js
@@ -1,0 +1,8 @@
+const getItemKey = key => item => {
+  if (typeof key === 'function') return key(item);
+  if (typeof key === 'string') return item[key];
+  if (typeof item === 'string' || typeof item === 'number') return item;
+  return item.id || item.uid || item.key || item.value || item.name || item.title;
+};
+
+export default getItemKey;


### PR DESCRIPTION
- change behavior of `itemKey` prop if nothing is provided. This is taken into account in List, Group and Sortable.
- New "Simple" story in List (just passing an array of string as items)
- New "Nested custom" story in List
- add `hover` state to list (works like `active`)

No visual changes