### PR TITLE
bugfix/fix line height in text field

### DIFF
--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -60,6 +60,7 @@
   flex: 1;
   flex-basis: auto;
   min-width: 0;
+  line-height: 1;
 
   &::placeholder {
     color: $coolgrey-40;


### PR DESCRIPTION
Fix line height for Text input for IE
before: 
![image](https://user-images.githubusercontent.com/5168044/61806768-8e481100-ae38-11e9-8212-431bc64193ae.png)


After: 
![image](https://user-images.githubusercontent.com/5168044/61806796-9d2ec380-ae38-11e9-99c5-daf541d488a2.png)
