### PR TITLE
IE11 : drop down list icon not displayed

### DIFF
--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -58,7 +58,7 @@
   @extend %text-ellipsis;
 
   flex: 1;
-  flex-basis: auto;
+  flex-basis: 0;
   min-width: 0;
   line-height: 1;
 


### PR DESCRIPTION
currentresult on ie: 
![image](https://user-images.githubusercontent.com/29209404/62453639-05ec3900-b773-11e9-9067-d6c2a69cdc71.png)
