### PR TITLE
bugfix/Fix checkbox and switch on List

### DIFF
--- a/src/alto-ui/List/List.js
+++ b/src/alto-ui/List/List.js
@@ -89,7 +89,7 @@ const renderField = (field, item, itemIndex, id, handleChange, onClick, active, 
       return (
         <Switch
           id={id}
-          checked={value}
+          checked={!!value}
           label={field.key}
           hideLabel
           small={small}
@@ -98,11 +98,12 @@ const renderField = (field, item, itemIndex, id, handleChange, onClick, active, 
         />
       );
 
+
     case 'checkbox':
       return (
         <CheckBox
           id={id}
-          checked={value}
+          checked={!!value}
           label={field.key}
           hideLabel
           onChange={e => handleChange(e.target.checked)}


### PR DESCRIPTION
Fix checkbox and switch change state in Alto LIst. 
Those components are rendered in List and get `value` for `checked` property. 
Sometimes value in alto lists for a quick time becomes null so React doesn't know that this is controlled or uncontrolled input. 

More description of the issue: https://stackoverflow.com/questions/53071743/react-a-component-is-changing-an-uncontrolled-input-of-type-checkbox-to-be-contr