### PR TITLE
bugfix/Change Side Nav links color for light theme

### DIFF
--- a/src/alto-ui/SideNav/SideNav.scss
+++ b/src/alto-ui/SideNav/SideNav.scss
@@ -99,6 +99,7 @@ $nav-btn-hover-text-dark: $white;
   height: $spacing-xx-large;
   cursor: pointer;
   transition: all $transition;
+  text-transform: none;
   padding: 0;
 }
 
@@ -292,7 +293,7 @@ $nav-btn-hover-text-dark: $white;
     .sidenav__button,
     .sidenav__section-button,
     .sidenav__route-link {
-      color: $coolgrey-50;
+      color: $coolgrey-80;
 
       &:hover {
         background-color: $color; //mix($white, $coolgrey-90, 92%);
@@ -311,7 +312,7 @@ $nav-btn-hover-text-dark: $white;
     }
 
     .sidenav__route-link {
-      color: $coolgrey-40;
+      color: $coolgrey-80;
       &--active {
         background-color: $color;
         color: $white;


### PR DESCRIPTION
Change color of links in Side nav to $coolgrey-80
![image](https://user-images.githubusercontent.com/5168044/62998569-3c5d3e80-be6c-11e9-94ca-9fd6b5ac8661.png)
