### PR TITLE
bugfix/Fix typeahead text fields on IE

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
@@ -107,12 +107,7 @@
 
   @extend %text-ellipsis;
 
-  &--header {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    line-height: $spacing-medium;
-  }
+
 
   &--compact:not(.DatagridCell__content--header):not(.DatagridCell__content--editable) {
     height: $height-small;
@@ -128,6 +123,13 @@
     height: $height-large;
     line-height: $height-large;
     font-size: $font-size-medium;
+  }
+
+  &--header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    line-height: $spacing-medium;
   }
 
   &--editing {

--- a/src/alto-ui/Form/TextField/TextField.scss
+++ b/src/alto-ui/Form/TextField/TextField.scss
@@ -121,6 +121,6 @@
   }
 }
 
-.textfield--right {
+.textfield--right, .textfield__input--right {
   text-align: right;
 }

--- a/src/alto-ui/Form/Typeahead/Typeahead.scss
+++ b/src/alto-ui/Form/Typeahead/Typeahead.scss
@@ -55,5 +55,5 @@
 }
 
 .Typeahead__input .textfield__input {
-  flex-basis: 0;
+  flex-basis: auto;
 }


### PR DESCRIPTION
Fix for fields components that use Typeahead  on InternetExplorer + align text in cell Datagrid