### PR TITLE
bugfix/Pass default property checked to checkbox to avoid sending null

### DIFF
--- a/src/alto-ui/Form/CheckBox/CheckBox.js
+++ b/src/alto-ui/Form/CheckBox/CheckBox.js
@@ -28,7 +28,9 @@ const CheckBox = React.forwardRef(
   )
 );
 
-CheckBox.defaultProps = {};
+CheckBox.defaultProps = {
+  checked: false,
+};
 
 CheckBox.propTypes = {
   label: PropTypes.string.isRequired,


### PR DESCRIPTION
Pass default property checked to avoid situation when goes null to checked - in this situation React doesn't know if this form is controlled or not.