### PR TITLE
bugfix/Add missing props to list with badges

### DIFF
--- a/src/alto-ui/List/List.js
+++ b/src/alto-ui/List/List.js
@@ -80,7 +80,7 @@ const renderField = (field, item, itemIndex, id, handleChange, onClick, active, 
                   : {};
               return (
                 <Badge key={key} {...props} {...badgeProps}>
-                  {badgeProps.children || children}
+                  {badgeProps.children || props.children || children}
                 </Badge>
               );
             }}


### PR DESCRIPTION
Add missing props when there is no element props passed - should display children from props