### PR TITLE
bugfix - fixed clear input for datepicker

### DIFF
--- a/src/alto-ui/Form/DatePicker/DatePicker.js
+++ b/src/alto-ui/Form/DatePicker/DatePicker.js
@@ -146,7 +146,6 @@ function DatePicker(props) {
         onClear={() => {
           handleChange('');
           setValue('');
-          setOpen(false);
         }}
       >
         {input => (


### PR DESCRIPTION
Date picker input field was not clearable.
Now on click [x] the field can be clear.