### PR TITLE
bugfix DatagridRows: display is broken when column groupedby is not visible

### DIFF
--- a/src/alto-ui/Datagrid/Datagrid.js
+++ b/src/alto-ui/Datagrid/Datagrid.js
@@ -397,7 +397,7 @@ class Datagrid extends React.PureComponent {
           </DatagridGroupedRow>
         ) : null;
 
-      const groupedRowArr = groupedRow ? [groupedRow] : [];
+      const groupedRowArr = groupedRow && groupingColumn ? [groupedRow] : [];
       const { labels } = this.getContext();
       const ariaRowIndex = rowIndex + groupedRowArr.length + 1;
       return [


### PR DESCRIPTION
display grouped rows only if the columns groupedby is displayed