### PR TITLE
Bugfix - Active row needs to have white inputs

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
+++ b/src/alto-ui/Datagrid/components/DatagridCell/DatagridCell.scss
@@ -232,6 +232,10 @@
     height: $height-datagrid-comfortable - 0.75;
     line-height: $height-datagrid-comfortable - 0.75;
   }
+
+  &.DatagridCell__content--selected {
+    background-color: $white;
+  }
 }
 
 .DatagridCell__content--edited {


### PR DESCRIPTION
Before: 
![before](https://user-images.githubusercontent.com/26206390/65962589-51f8e880-e459-11e9-9713-40264e3d5362.png)

After: 
![after](https://user-images.githubusercontent.com/26206390/65962593-56250600-e459-11e9-967e-8c0192db61e7.png)
