### PR TITLE
Remove onClose on onBlur

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/DatagridCellInput.js
@@ -58,7 +58,6 @@ class DatagridCellInput extends React.Component {
     } = this.props;
 
     const sharedProps = this.getSharedProps();
-
     switch (type) {
       case 'list':
       case 'select':
@@ -71,7 +70,6 @@ class DatagridCellInput extends React.Component {
           onClose: this.handleBlur,
           clearable: true,
           edited: modifiers.edited,
-          isDataGridCell: true,
           ...inputProps,
         };
       case 'boolean':

--- a/src/alto-ui/Form/Typeahead/Typeahead.js
+++ b/src/alto-ui/Form/Typeahead/Typeahead.js
@@ -111,7 +111,6 @@ const Typeahead = React.forwardRef(
       itemKey,
       clearable,
       edited,
-      isDataGridCell,
       ...props
     },
     passedRef
@@ -259,7 +258,6 @@ const Typeahead = React.forwardRef(
                     inputRef.current.focus();
                   } else {
                     if (typeof props.onBlur === 'function') props.onBlur(e);
-                    if (isDataGridCell) closeMenu();
                     setFocus(false);
                   }
                 },


### PR DESCRIPTION
Removed isDataGridCell prop from typeahead, removed onClose if onBlur

BUG: When clicking on the RemoveIcon it was forcing onClose