### PR TITLE
horizontal scroll is not needed for grid if grid is too short

### DIFF
--- a/src/alto-ui/Datagrid/Datagrid.scss
+++ b/src/alto-ui/Datagrid/Datagrid.scss
@@ -17,7 +17,7 @@
   bottom: 0;
   right: $height-scrollbar;
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
   z-index: 1000;
 }
 


### PR DESCRIPTION
horizontal scroll is not needed for grid if grid is too short