### PR TITLE
Reduce letter spacing in header title

### DIFF
--- a/src/alto-ui/Header/Header.scss
+++ b/src/alto-ui/Header/Header.scss
@@ -34,7 +34,7 @@
 .Header__title {
   font-size: 1.125rem;
   font-weight: $font-weight-bold;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.025em;
 }
 
 .Header__loader {


### PR DESCRIPTION
Halved the letter spacing of the header title
<img width="994" alt="Screenshot 2019-11-14 at 14 35 09" src="https://user-images.githubusercontent.com/33580481/68862259-6df4d880-06ed-11ea-8340-a73280fede2f.png">
