### PR TITLE
Add hover state on button group

### DIFF
--- a/src/alto-ui/ButtonGroup/ButtonGroup.scss
+++ b/src/alto-ui/ButtonGroup/ButtonGroup.scss
@@ -41,6 +41,11 @@
     outline: none;
   }
 
+  &:hover {
+    color: $blue-50;
+    border-color: $blue-50;
+  }
+
   &--disabled {
     cursor: not-allowed;
     color: $coolgrey-60;
@@ -51,6 +56,11 @@
   &--active {
     background-color: $blue-70;
     color: $white;
+
+    &:hover {
+      background-color: $blue-50;
+      color: $white;
+    }
 
     &.ButtonGroup__button--disabled {
       background-color: $coolgrey-60;


### PR DESCRIPTION
Buttons in button group are now displayed in blue-50 on mouse hover.

<img width="1072" alt="Screenshot 2019-11-14 at 15 51 37" src="https://user-images.githubusercontent.com/33580481/68867938-ea3fe980-06f6-11ea-8205-03d0e61e0a52.png">
