### PR TITLE
ennhancement - refactor DatagridResizer to func component

### DIFF
--- a/src/alto-ui/Datagrid/components/DatagridResizer/DatagridResizer.js
+++ b/src/alto-ui/Datagrid/components/DatagridResizer/DatagridResizer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 
@@ -6,65 +6,55 @@ import { bemClass } from '../../../helpers/bem';
 
 import './DatagridResizer.scss';
 
-class DatagridResizer extends React.Component {
-  constructor(props) {
-    super(props);
+const DatagridResizer = ({
+  left,
+  top,
+  handleHeight,
+  height,
+  maxLeft,
+  maxRight,
+  resizing,
+  onStart,
+  onStop,
+}) => {
+  const [leftValue, setLeftValue] = useState(0);
+  const [x, setX] = useState(0);
 
-    this.state = {
-      // eslint-disable-next-line react/no-unused-state
-      props,
-      x: 0,
-    };
-
-    this.handleDrag = this.handleDrag.bind(this);
-    this.handleStart = this.handleStart.bind(this);
-    this.handleStop = this.handleStop.bind(this);
+  if (left !== leftValue) {
+    setX(0);
+    setLeftValue(left);
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.left !== state.props.left) return { x: 0, props };
-    return null;
-  }
+  const handleStop = () => {
+    onStop(x);
+  };
 
-  handleStart() {
-    this.props.onStart();
-  }
+  const handleDrag = (e, { x: xValue }) => {
+    setX(xValue);
+  };
 
-  handleStop() {
-    this.props.onStop(this.state.x);
-  }
-
-  handleDrag(e, { x }) {
-    this.setState({ x });
-  }
-
-  render() {
-    const { left, top, handleHeight, height, maxLeft, maxRight, resizing } = this.props;
-    const { x } = this.state;
-
-    return (
-      <Draggable
-        axis="x"
-        position={{ x, y: 0 }}
-        bounds={{ left: maxLeft - left, right: maxRight - left, top: 0, bottom: 0 }}
-        onStart={this.handleStart}
-        onDrag={this.handleDrag}
-        onStop={this.handleStop}
+  return (
+    <Draggable
+      axis="x"
+      position={{ x, y: 0 }}
+      bounds={{ left: maxLeft - left, right: maxRight - left, top: 0, bottom: 0 }}
+      onStart={onStart}
+      onDrag={handleDrag}
+      onStop={handleStop}
+    >
+      <div
+        className={bemClass('DatagridResizer', { dragging: resizing })}
+        style={{
+          height: handleHeight,
+          left,
+          top,
+        }}
       >
-        <div
-          className={bemClass('DatagridResizer', { dragging: resizing })}
-          style={{
-            height: handleHeight,
-            left,
-            top,
-          }}
-        >
-          <div className="DatagridResizer__ruler" style={{ height }} />
-        </div>
-      </Draggable>
-    );
-  }
-}
+        <div className="DatagridResizer__ruler" style={{ height }} />
+      </div>
+    </Draggable>
+  );
+};
 
 DatagridResizer.displayName = 'DatagridResizer';
 

--- a/src/alto-ui/Datagrid/components/DatagridResizer/__tests__/DatagridResizer.test.js
+++ b/src/alto-ui/Datagrid/components/DatagridResizer/__tests__/DatagridResizer.test.js
@@ -19,6 +19,7 @@ describe('DatagridResizer component', () => {
 
   const getWrapper = (props = {}, fn = shallow) =>
     fn(<DatagridResizer {...mockedProps} {...props} />);
+
   it('should render Draggable component', () => {
     const wrapper = getWrapper();
 
@@ -72,13 +73,13 @@ describe('DatagridResizer component', () => {
     const mouseMove = new Event('mousemove');
     wrapper.find(Draggable).invoke('onDrag')(mouseMove, { x: 900 });
 
-    expect(wrapper.state('x')).toBe(900);
+    expect(wrapper.find(Draggable).prop('position')).toEqual({ x: 900, y: 0 });
   });
 
   it('should properly update state when props changed', () => {
     const wrapper = getWrapper();
     wrapper.setProps({ left: 500 });
 
-    expect(wrapper.state('x')).toBe(0);
+    expect(wrapper.find(Draggable).prop('position')).toEqual({ x: 0, y: 0 });
   });
 });


### PR DESCRIPTION
- [x] Refactor DatagridResizer into functional component;
- [x] align test cases to work with funtional component;

It needed to upgrade React at least to v16.8.5 in which was fixed created to working with shallow and useState