### PR TITLE
enhancement - move DatagridResizer to DatagridHead

### DIFF
--- a/src/alto-ui/Datagrid/__tests__/Datagrid.test.js
+++ b/src/alto-ui/Datagrid/__tests__/Datagrid.test.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import Datagrid from '../Datagrid';
 
-import DatagridResizer from '../components/DatagridResizer';
 import DatagridHead from '../components/DatagridHead';
 import DatagridContent from '../components/DatagridContent';
 
 jest.mock('../components/DatagridHead', () => () => null);
 jest.mock('../components/DatagridContent', () => () => null);
-jest.mock('../components/DatagridResizer', () => () => null);
 
 describe('Datagrid', () => {
   const defaultProps = {
@@ -17,14 +16,11 @@ describe('Datagrid', () => {
     rows: [],
     rowKeyField: jest.fn('key'),
   };
-
   const getWrapper = props => shallow(<Datagrid {...defaultProps} {...props} />);
-
   it('should render it self', () => {
-   const wrapper = getWrapper();
+    const wrapper = getWrapper();
 
-   expect(wrapper.find(DatagridResizer)).toHaveLength(1);
-   expect(wrapper.find(DatagridHead)).toHaveLength(1);
-   expect(wrapper.find(DatagridContent)).toHaveLength(1);
+    expect(wrapper.find(DatagridHead)).toHaveLength(1);
+    expect(wrapper.find(DatagridContent)).toHaveLength(1);
   });
 });

--- a/src/alto-ui/Datagrid/components/DatagridCellInput/__tests__/DatagridCellInput.test.js
+++ b/src/alto-ui/Datagrid/components/DatagridCellInput/__tests__/DatagridCellInput.test.js
@@ -35,7 +35,6 @@ jest.mock('../../../../Input', () => {
   });
 });
 
-
 describe('DatagridCellInput', () => {
   const ENTER_KEY_CODE = 13;
   const ESC_KEY_CODE = 27;
@@ -60,7 +59,6 @@ describe('DatagridCellInput', () => {
   const secondMockValue = { value: 'mockedData2' };
 
   const getWrapper = props => mount(<DatagridCellInput {...propsMock} {...props} />);
-
 
   it('should mount input', () => {
     const input = getWrapper().find('input');
@@ -130,7 +128,6 @@ describe('DatagridCellInput', () => {
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ ...firstMockValue }));
       expect(onStopEditing).toHaveBeenCalledWith(expect.objectContaining({ ...firstMockValue }));
 
-
       wrapper.simulate('change', secondMockValue);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ ...secondMockValue }));
       expect(onStopEditing).toHaveBeenCalledWith(expect.objectContaining({ ...secondMockValue }));
@@ -176,67 +173,63 @@ describe('DatagridCellInput', () => {
   });
 
   describe('Check passed props', () => {
-    const getValuesWithoutUdefined = values => Object.keys(values).reduce((acc, key) => {
-      const prop = values[key];
-      if (typeof prop === 'undefined') {
-        return acc;
-      }
+    const getValuesWithoutUdefined = values =>
+      Object.keys(values).reduce((acc, key) => {
+        const prop = values[key];
+        if (typeof prop === 'undefined') {
+          return acc;
+        }
 
-      return {
-        ...acc,
-        [key]: prop,
-      };
-    }, {});
+        return {
+          ...acc,
+          [key]: prop,
+        };
+      }, {});
 
     const getPropsWithoutUndefined = wrapper => {
       const props = wrapper.find('input').props();
 
-      const {
-        otherprops,
-        ...result
-      } = getValuesWithoutUdefined(props);
+      const { otherprops, ...result } = getValuesWithoutUdefined(props);
 
       return {
         ...result,
         otherprops: getValuesWithoutUdefined(otherprops),
-      }
+      };
     };
 
     const expectChangeInputProps = wrapper => {
       const onKeyDown = jest.fn();
-        const onChange = jest.fn();
-        const onClose = jest.fn();
-        const onBlur = jest.fn();
-        wrapper.setProps({
-          inputProps: {
-            onKeyDown,
-            onChange,
-            onClose,
-            onBlur,
-            value: 'abc',
-          },
-        });
-        const input = wrapper.find('input');
+      const onChange = jest.fn();
+      const onClose = jest.fn();
+      const onBlur = jest.fn();
+      wrapper.setProps({
+        inputProps: {
+          onKeyDown,
+          onChange,
+          onClose,
+          onBlur,
+          value: 'abc',
+        },
+      });
+      const input = wrapper.find('input');
 
-        expect(input.prop('value')).toBe('abc');
+      expect(input.prop('value')).toBe('abc');
 
-        input.simulate('keyDown', { keyCode: ESC_KEY_CODE });
-        expect(onKeyDown).toHaveBeenCalledTimes(1);
-        input.simulate('change');
-        expect(onChange).toHaveBeenCalledTimes(1);
-        input.simulate('close');
-        expect(onClose).toHaveBeenCalledTimes(1);
-        input.simulate('blur');
-        expect(onBlur).toHaveBeenCalledTimes(1);
+      input.simulate('keyDown', { keyCode: ESC_KEY_CODE });
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      input.simulate('change');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      input.simulate('close');
+      expect(onClose).toHaveBeenCalledTimes(1);
+      input.simulate('blur');
+      expect(onBlur).toHaveBeenCalledTimes(1);
     };
 
     describe('list && select types', () => {
       const wrapper = getWrapper();
       const {
         id,
-        column: {
-          title: label,
-        },
+        column: { title: label },
       } = propsMock;
 
       const expected = {
@@ -291,9 +284,7 @@ describe('DatagridCellInput', () => {
       const wrapper = getWrapper();
       const {
         id,
-        column: {
-          title: label,
-        },
+        column: { title: label },
       } = propsMock;
 
       const expected = {
@@ -304,7 +295,7 @@ describe('DatagridCellInput', () => {
         onChange: expect.any(Function),
         className: expect.any(String),
         value: '',
-        otherprops: { hideLabel: true }
+        otherprops: { hideLabel: true },
       };
 
       beforeEach(() => {
@@ -324,9 +315,7 @@ describe('DatagridCellInput', () => {
       const wrapper = getWrapper();
       const {
         id,
-        column: {
-          title: label,
-        },
+        column: { title: label },
       } = propsMock;
 
       const expected = {
@@ -352,7 +341,11 @@ describe('DatagridCellInput', () => {
         wrapper.setProps({ type: 'integer' });
         expect(getPropsWithoutUndefined(wrapper)).toEqual({ ...expected, type: 'integer' });
         wrapper.setProps({ type: 'float', value: 'abc' });
-        expect(getPropsWithoutUndefined(wrapper)).toEqual({ ...expected, type: 'float', value: 'abc' });
+        expect(getPropsWithoutUndefined(wrapper)).toEqual({
+          ...expected,
+          type: 'float',
+          value: 'abc',
+        });
       });
 
       it('should insert additional inputProps', () => {
@@ -364,9 +357,7 @@ describe('DatagridCellInput', () => {
       const wrapper = getWrapper();
       const {
         id,
-        column: {
-          title: label,
-        },
+        column: { title: label },
       } = propsMock;
 
       const expected = {
@@ -395,7 +386,11 @@ describe('DatagridCellInput', () => {
         wrapper.setProps({ type: 'datetime' });
         expect(getPropsWithoutUndefined(wrapper)).toEqual({ ...expected, type: 'datetime' });
         wrapper.setProps({ value: 'ooo' });
-        expect(getPropsWithoutUndefined(wrapper)).toEqual({ ...expected, type: 'datetime', value: 'ooo' });
+        expect(getPropsWithoutUndefined(wrapper)).toEqual({
+          ...expected,
+          type: 'datetime',
+          value: 'ooo',
+        });
       });
 
       it('should insert additional inputProps', () => {

--- a/src/alto-ui/Datagrid/components/DatagridHead/DatagridHead.js
+++ b/src/alto-ui/Datagrid/components/DatagridHead/DatagridHead.js
@@ -1,11 +1,12 @@
-import React, { memo, forwardRef } from 'react';
+import React, { useState, memo, forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { bemClass } from '../../../helpers/bem';
-import { DATAGRID_HEADER_ROW_INDEX } from '../../constants';
+import { DATAGRID_HEADER_ROW_INDEX, DATAGRID_INITIAL_STATE_RESIZER } from '../../constants';
 import DatagridHeaderRow from '../DatagridHeaderRow';
 import { DatagridHeadSummaryRow } from './components/DatagridHeadSummaryRow';
-
+import DatagridResizer from '../DatagridResizer';
+import { DatagridContext } from '../../Datagrid';
 
 const DatagridHead = memo(
   ({
@@ -17,58 +18,109 @@ const DatagridHead = memo(
     rowsWidth,
     staticColumnHeaders,
     staticColumns,
+    containerRef,
+    setColumnsWidth,
+    onChangeWidth,
     scrollHeaderRef,
   }) => {
+    const context = useContext(DatagridContext);
+    const { columnsWidth } = context;
+    const [resizer, setResizer] = useState(DATAGRID_INITIAL_STATE_RESIZER);
     const isFrozenColumnsAvailable = frozenColumns.length || hasCheckbox;
 
+    const { target, container, parent, resizing, column } = resizer;
+    const minWidth = column && column.editable ? 74 : 64;
+
+    const handleMouseEnterResizeHandle = (e, col) => {
+      if (resizer.resizing) return;
+      const resizerTarget = e.target.getBoundingClientRect();
+      const resizerParent = e.target.parentNode.getBoundingClientRect();
+      const resizerContainer = containerRef.current.getBoundingClientRect();
+      setResizer({
+        column: col,
+        target: resizerTarget,
+        parent: resizerParent,
+        container: resizerContainer,
+        resizing: false,
+      });
+    };
+
+    const handleStartResize = () => {
+      setResizer({ ...resizer, resizing: true });
+    };
+
+    const handleStopResize = deltaX => {
+      if (typeof onChangeWidth === 'function') {
+        const value = resizer.parent.width + deltaX;
+        onChangeWidth(value, resizer.column);
+      }
+      setResizer(DATAGRID_INITIAL_STATE_RESIZER);
+      setColumnsWidth({ ...columnsWidth, [resizer.column.key]: resizer.parent.width + deltaX });
+    };
+
     return (
-      <div role="rowgroup" className="Datagrid__head">
-        {isFrozenColumnsAvailable && (
-          <div role="presentation" className={bemClass('Datagrid__header-row', { frozen: true })}>
-            <DatagridHeaderRow
-              columns={frozenColumnHeaders}
-              rowIndex={DATAGRID_HEADER_ROW_INDEX}
-              frozen
-              hasCheckBox={hasCheckbox}
-            />
-            {staticColumns.length && renderSummaryCell && (
-              <DatagridHeadSummaryRow
-                isFrozen
-                columns={frozenColumns}
-                numberOfRows={staticColumns.length}
-                rowHasCheckbox={hasCheckbox && true}
-                renderSummaryCell={renderSummaryCell}
-                headerClassModifiers={headerClassModifiers}
+      <>
+        <DatagridResizer
+          left={target.left}
+          top={target.top}
+          handleHeight={target.height}
+          height={container.bottom - target.top}
+          maxLeft={parent.left + minWidth}
+          maxRight={column && column.frozen ? container.right - minWidth : container.right}
+          onStart={handleStartResize}
+          onStop={handleStopResize}
+          resizing={resizing}
+        />
+        <div role="rowgroup" className="Datagrid__head">
+          {isFrozenColumnsAvailable && (
+            <div role="presentation" className={bemClass('Datagrid__header-row', { frozen: true })}>
+              <DatagridHeaderRow
+                columns={frozenColumnHeaders}
+                rowIndex={DATAGRID_HEADER_ROW_INDEX}
+                frozen
+                hasCheckBox={hasCheckbox}
+                onMouseEnterResizeHandle={handleMouseEnterResizeHandle}
               />
-            )}
-          </div>
-        )}
-        <div ref={scrollHeaderRef} className="Datagrid__header-row-container">
-          <div
-            role="presentation"
-            className={bemClass('Datagrid__header-row', { static: true })}
-            style={{ width: rowsWidth }}
-          >
-            <DatagridHeaderRow
-              columns={staticColumnHeaders}
-              rowIndex={DATAGRID_HEADER_ROW_INDEX}
-              columnIndexStart={frozenColumns.length}
-              frozen={false}
-            />
-            {staticColumns.length && renderSummaryCell && (
-              <DatagridHeadSummaryRow
-                columns={staticColumns}
-                isFrozen={false}
-                rowHasCheckbox={hasCheckbox && false}
-                rowHeadersCount={1}
+              {staticColumns.length && renderSummaryCell && (
+                <DatagridHeadSummaryRow
+                  isFrozen
+                  columns={frozenColumns}
+                  numberOfRows={staticColumns.length}
+                  rowHasCheckbox={hasCheckbox && true}
+                  renderSummaryCell={renderSummaryCell}
+                  headerClassModifiers={headerClassModifiers}
+                />
+              )}
+            </div>
+          )}
+          <div ref={scrollHeaderRef} className="Datagrid__header-row-container">
+            <div
+              role="presentation"
+              className={bemClass('Datagrid__header-row', { static: true })}
+              style={{ width: rowsWidth }}
+            >
+              <DatagridHeaderRow
+                columns={staticColumnHeaders}
+                rowIndex={DATAGRID_HEADER_ROW_INDEX}
                 columnIndexStart={frozenColumns.length}
-                renderSummaryCell={renderSummaryCell}
-                headerClassModifiers={headerClassModifiers}
+                frozen={false}
+                onMouseEnterResizeHandle={handleMouseEnterResizeHandle}
               />
-            )}
+              {staticColumns.length && renderSummaryCell && (
+                <DatagridHeadSummaryRow
+                  columns={staticColumns}
+                  isFrozen={false}
+                  rowHasCheckbox={hasCheckbox && false}
+                  rowHeadersCount={1}
+                  columnIndexStart={frozenColumns.length}
+                  renderSummaryCell={renderSummaryCell}
+                  headerClassModifiers={headerClassModifiers}
+                />
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </>
     );
   }
 );
@@ -91,6 +143,9 @@ DatagridHead.propTypes = {
     PropTypes.shape({ key: PropTypes.string.isRequired, title: PropTypes.string.isRequired })
   ),
   scrollHeaderRef: PropTypes.object,
+  containerRef: PropTypes.object,
+  setColumnsWidth: PropTypes.func,
+  onChangeWidth: PropTypes.func,
 };
 
 export default forwardRef(({ ...props }, ref) => <DatagridHead {...props} scrollHeaderRef={ref} />);

--- a/src/alto-ui/Datagrid/components/DatagridHeaderCell/DatagridHeaderCell.js
+++ b/src/alto-ui/Datagrid/components/DatagridHeaderCell/DatagridHeaderCell.js
@@ -23,15 +23,13 @@ const areEqual = (prevProps, nextProps) => {
 const DatagridHeaderCell = memo(
   ({
     column,
-    context: {
-      wrapHeader,
-      columnSorted,
-      onSort,
-      onMouseEnterResizeHandle,
-      sortDirection,
-      id,
-      labels,
-    },
+    wrapHeader,
+    columnSorted,
+    onSort,
+    onMouseEnterResizeHandle,
+    sortDirection,
+    id,
+    labels,
     rowIndex,
     colIndex,
     last,
@@ -49,9 +47,7 @@ const DatagridHeaderCell = memo(
 
     const sorted = column.key === columnSorted || [1, -1].includes(column.sortDirection);
 
-    const handleMouseEnterResizeHandle = e => {
-      onMouseEnterResizeHandle(e, column);
-    };
+    const handleMouseEnterResizeHandle = e => onMouseEnterResizeHandle(e, column);
 
     return (
       <div
@@ -98,24 +94,22 @@ DatagridHeaderCell.defaultProps = {
 };
 
 DatagridHeaderCell.propTypes = {
-  context: PropTypes.shape({
-    labels: PropTypes.shape({
-      a11ySortLabel: PropTypes.string.isRequired,
-    }).isRequired,
-    onMouseEnterResizeHandle: PropTypes.func.isRequired,
-    sortDirection: PropTypes.number,
-    onSort: PropTypes.func,
-    columnSorted: PropTypes.arrayOf(
-      PropTypes.shape({
-        key: PropTypes.any.isRequired,
-        title: PropTypes.any.isRequired,
-        description: PropTypes.string,
-        type: PropTypes.string,
-        width: PropTypes.number,
-        formula: PropTypes.string,
-      })
-    ),
+  labels: PropTypes.shape({
+    a11ySortLabel: PropTypes.string.isRequired,
   }).isRequired,
+  onMouseEnterResizeHandle: PropTypes.func.isRequired,
+  sortDirection: PropTypes.number,
+  onSort: PropTypes.func,
+  columnSorted: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.any.isRequired,
+      title: PropTypes.any.isRequired,
+      description: PropTypes.string,
+      type: PropTypes.string,
+      width: PropTypes.number,
+      formula: PropTypes.string,
+    })
+  ),
   column: PropTypes.shape({
     key: PropTypes.any.isRequired,
     title: PropTypes.any.isRequired,
@@ -129,6 +123,6 @@ DatagridHeaderCell.propTypes = {
   last: PropTypes.bool,
   width: PropTypes.number,
 };
-DatagridHeaderCell.displayName='DataGridHeaderCell';
+DatagridHeaderCell.displayName = 'DataGridHeaderCell';
 
 export default DatagridHeaderCell;

--- a/src/alto-ui/Datagrid/components/DatagridHeaderCell/__tests__/DatagridHeaderCell.test.js
+++ b/src/alto-ui/Datagrid/components/DatagridHeaderCell/__tests__/DatagridHeaderCell.test.js
@@ -6,14 +6,12 @@ import DataGridHeaderCellContent from '../DatagridHeaderCellContent';
 
 describe('DatagridHeaderCell component', () => {
   const props = {
-    context: {
-      labels: {
-        a11ySortLabel: 'title',
-      },
-      onMouseEnterResizeHandle: jest.fn(),
-      wrapHeader: true,
-      onSort: jest.fn(),
+    labels: {
+      a11ySortLabel: 'title',
     },
+    onMouseEnterResizeHandle: jest.fn(),
+    wrapHeader: true,
+    onSort: jest.fn(),
     column: {
       key: '1',
       title: 'Column Title',
@@ -46,10 +44,7 @@ describe('DatagridHeaderCell component', () => {
         minWidth: '2rem',
         maxWidth: 200,
       };
-      const {
-        context: { onSort, sortDirection, id, labels },
-        column,
-      } = props;
+      const { onSort, sortDirection, id, labels, column } = props;
 
       expect(wrapper.find(DataGridHeaderCellContent).prop('style')).toEqual(style);
       expect(wrapper.find(DataGridHeaderCellContent).prop('sorted')).toBe(true);
@@ -83,9 +78,7 @@ describe('DatagridHeaderCell component', () => {
 
     it('to .DatagridHeaderCell__resize-handle', () => {
       const wrapper = shallow(<DatagridHeaderCell {...props} />);
-      const {
-        context: { onMouseEnterResizeHandle },
-      } = props;
+      const { onMouseEnterResizeHandle } = props;
 
       expect(typeof wrapper.find('.DatagridHeaderCell__resize-handle').prop('onMouseEnter')).toBe(
         'function'

--- a/src/alto-ui/Datagrid/components/DatagridHeaderRow/DatagridHeaderRow.js
+++ b/src/alto-ui/Datagrid/components/DatagridHeaderRow/DatagridHeaderRow.js
@@ -65,13 +65,21 @@ const renderCheckbox = (context, columns) => {
   );
 };
 
-function DatagridHeaderRow({ columns, rowIndex, columnIndexStart, hasCheckBox, frozen }) {
+function DatagridHeaderRow({
+  columns,
+  rowIndex,
+  columnIndexStart,
+  hasCheckBox,
+  frozen,
+  onMouseEnterResizeHandle,
+}) {
   const context = useContext(DatagridContext);
+  const { wrapHeader, columnSorted, onSort, sortDirection, id, labels } = context;
+  const { columnsWidth } = context;
   return (
     <div role="row" aria-rowindex={rowIndex} className={bemClass('DatagridHeaderRow', { frozen })}>
       {hasCheckBox && renderCheckbox(context, columns)}
       {columns.map((column, colIndex) => {
-        const { columnsWidth } = context;
         const firstCellInRow =
           typeof context.onSelectRow !== 'function' && columnIndexStart + colIndex === 0;
         if (!column.children) {
@@ -87,6 +95,13 @@ function DatagridHeaderRow({ columns, rowIndex, columnIndexStart, hasCheckBox, f
               firstRow
               firstCellInRow={firstCellInRow}
               lastCellInRow={columnIndexStart + colIndex === context.columns.length - 1}
+              wrapHeader={wrapHeader}
+              columnSorted={columnSorted}
+              onSort={onSort}
+              onMouseEnterResizeHandle={onMouseEnterResizeHandle}
+              sortDirection={sortDirection}
+              id={id}
+              labels={labels}
             />
           );
         }
@@ -162,6 +177,7 @@ DatagridHeaderRow.propTypes = {
   columnIndexStart: PropTypes.number,
   hasCheckBox: PropTypes.bool,
   frozen: PropTypes.bool,
+  onMouseEnterResizeHandle: PropTypes.func,
 };
 
 export default DatagridHeaderRow;

--- a/src/alto-ui/Datagrid/components/DatagridResizer/DatagridResizer.js
+++ b/src/alto-ui/Datagrid/components/DatagridResizer/DatagridResizer.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
 
@@ -45,8 +45,9 @@ const DatagridResizer = ({
         <div className="DatagridResizer__ruler" style={{ height }} />
       </div>
     ),
-    [left]
+    [resizing, left]
   );
+
   return (
     <Draggable
       axis="x"


### PR DESCRIPTION
- [x] Move DatagridResizer component from Datagrid to DatagridHead to avoid rerendering whole grid when setResizer is invoked